### PR TITLE
Ab#750 event log

### DIFF
--- a/src/api/AdminEventsRepository.js
+++ b/src/api/AdminEventsRepository.js
@@ -1,0 +1,10 @@
+import { kcRequest } from "./Repository";
+
+const resource = "/admin-events";
+
+export default {
+
+    getEvents() {
+        return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}`));
+    }
+}

--- a/src/api/EventsRepository.js
+++ b/src/api/EventsRepository.js
@@ -1,0 +1,10 @@
+import { kcRequest } from "./Repository";
+
+const resource = "/events";
+
+export default {
+
+    getEvents() {
+        return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}`));
+    }
+}

--- a/src/api/RepositoryFactory.js
+++ b/src/api/RepositoryFactory.js
@@ -1,9 +1,13 @@
 import ClientsRepository from './ClientsRepository';
 import UsersRepository from './UsersRepository';
+import EventsRepository from "./EventsRepository";
+import AdminEventsRepository from "./AdminEventsRepository";
 
 const repositories = {
     clients: ClientsRepository,
-    users: UsersRepository
+    users: UsersRepository,
+    events: EventsRepository,
+    adminEvents: AdminEventsRepository
 };
 
 export const RepositoryFactory = {

--- a/src/components/template/TheNavBar.vue
+++ b/src/components/template/TheNavBar.vue
@@ -3,10 +3,13 @@
     <div class="container">
       <ul>
         <li id="users-link" :class="($route.name == 'UserSearch' || $route.name == 'UserInfo') ? 'active' : 'inactive'">
-            <router-link :to="{ name: 'UserSearch'}"> Users</router-link>   
+            <router-link :to="{ name: 'UserSearch'}">Users</router-link>
         </li>
         <li id="event-log-link" :class="$route.name == 'EventLog' ? 'active' : 'inactive'">
             <router-link :to="{ name: 'EventLog'}">Event Log</router-link>
+        </li>
+        <li id="admin-event-log-link" :class="$route.name == 'AdminEventLog' ? 'active' : 'inactive'">
+            <router-link :to="{ name: 'AdminEventLog'}">Admin Event Log</router-link>
         </li>
       </ul>
     </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import Users from '../views/Users.vue'
 import UserSearch from '../components/UserSearch.vue'
 import UserInfo from '../components/UserInfo.vue'
 import EventLog from '../views/EventLog.vue'
+import AdminEventLog from '../views/AdminEventLog.vue'
 
 Vue.use(VueRouter)
 
@@ -29,6 +30,11 @@ const routes = [
     path: '/event-log',
     name: 'EventLog',
     component: EventLog
+  },
+  {
+    path: '/admin-event-log',
+    name: 'AdminEventLog',
+    component: AdminEventLog
   }
 ]
 

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -1,7 +1,10 @@
 <template>
     <div>
-        <button @click="getAdminEvents">Refresh</button>
-
+      <v-text-field
+          v-model="search"
+          append-icon="mdi-magnify"
+          label=" Search"
+      ></v-text-field>
         <v-data-table
                 :headers="headers"
                 :items="adminEvents"
@@ -12,11 +15,13 @@
                 item-key="key"
                 loading-text="Loading events"
                 :loading="loadingStatus"
+                :search="search"
         >
             <template v-slot:expanded-item="{ headers, item }">
                 <td :colspan="headers.length"><pre>{{item.representation | pretty}}</pre></td>
             </template>
         </v-data-table>
+        <button @click="getAdminEvents">Refresh</button>
     </div>
 </template>
 
@@ -32,14 +37,16 @@
         name: "AdminEventLog",
         data() {
             return {
+                search: '',
                 loadingStatus: false,
                 singleExpand: true,
                 adminEvents: [],
                 headers: [
                     { text: 'Time', value: 'readableDate'},
                     { text: 'Event type', value: 'operationType' },
+                    { text: 'Resource type', value: 'resourceType' },
                     { text: 'User', value: 'resourcePath' },
-                    // { text: 'Data', value: 'representation' },
+                    { text: 'Details', value: 'data-table-expand' },
                 ],
             }
         },
@@ -54,7 +61,7 @@
                 return AdminEventsRepository.getEvents()
                     .then(response => {
                         this.adminEvents = response.data;
-                        this.adminEvents = this.adminEvents.filter(value => value.resourceType === 'USER');
+                        // this.adminEvents = this.adminEvents.filter(value => value.resourceType === 'USER');
                         for (let [index, e] of this.adminEvents.entries()) {
                             e.key = index;
                             e.readableDate = formatDate(e.time);

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -26,9 +26,7 @@
 </template>
 
 <script>
-    import {RepositoryFactory} from "./../api/RepositoryFactory";
-
-    const AdminEventsRepository = RepositoryFactory.get("adminEvents");
+    import AdminEventsRepository from "../api/AdminEventsRepository";
 
     const options = {dateStyle: 'short', timeStyle: 'short'};
     const formatDate = new Intl.DateTimeFormat(undefined, options).format;
@@ -56,23 +54,19 @@
         },
 
         methods: {
-            getAdminEvents: function () {
-                this.loadingStatus = true;
-                return AdminEventsRepository.getEvents()
-                    .then(response => {
-                        this.adminEvents = response.data;
-                        // this.adminEvents = this.adminEvents.filter(value => value.resourceType === 'USER');
-                        for (let [index, e] of this.adminEvents.entries()) {
-                            e.key = index;
-                            e.readableDate = formatDate(e.time);
-                        }
-                    })
-                    .catch(e => {
-                        console.log(e);
-                        throw e;
-                    })
-                    .finally(() => this.loadingStatus = false);
+          getAdminEvents: async function () {
+            this.loadingStatus = true;
+            try {
+              let promise = await AdminEventsRepository.getEvents();
+              this.adminEvents = promise.data;
+              for (let [index, e] of this.adminEvents.entries()) {
+                e.key = index;
+                e.readableDate = formatDate(e.time);
+              }
+            } finally {
+              this.loadingStatus = false;
             }
+          }
         },
 
         filters: {

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -1,0 +1,80 @@
+<template>
+    <div>
+        <button @click="getAdminEvents">Refresh</button>
+
+        <v-data-table
+                :headers="headers"
+                :items="adminEvents"
+                :items-per-page="15"
+                class="elevation-1"
+                show-expand
+                :single-expand="singleExpand"
+                item-key="key"
+                loading-text="Loading events"
+                :loading="loadingStatus"
+        >
+            <template v-slot:expanded-item="{ headers, item }">
+                <td :colspan="headers.length"><pre>{{item.representation | pretty}}</pre></td>
+            </template>
+        </v-data-table>
+    </div>
+</template>
+
+<script>
+    import {RepositoryFactory} from "./../api/RepositoryFactory";
+
+    const AdminEventsRepository = RepositoryFactory.get("adminEvents");
+
+    const options = {dateStyle: 'short', timeStyle: 'short'};
+    const formatDate = new Intl.DateTimeFormat(undefined, options).format;
+
+    export default {
+        name: "AdminEventLog",
+        data() {
+            return {
+                loadingStatus: false,
+                singleExpand: true,
+                adminEvents: [],
+                headers: [
+                    { text: 'Time', value: 'readableDate'},
+                    { text: 'Event type', value: 'operationType' },
+                    { text: 'User', value: 'resourcePath' },
+                    // { text: 'Data', value: 'representation' },
+                ],
+            }
+        },
+
+        created() {
+            this.getAdminEvents();
+        },
+
+        methods: {
+            getAdminEvents: function () {
+                this.loadingStatus = true;
+                return AdminEventsRepository.getEvents()
+                    .then(response => {
+                        this.adminEvents = response.data;
+                        this.adminEvents = this.adminEvents.filter(value => value.resourceType === 'USER');
+                        for (let [index, e] of this.adminEvents.entries()) {
+                            e.key = index;
+                            e.readableDate = formatDate(e.time);
+                        }
+                    })
+                    .catch(e => {
+                        console.log(e);
+                        throw e;
+                    })
+                    .finally(() => this.loadingStatus = false);
+            }
+        },
+
+        filters: {
+            pretty: function(value) {
+                if (!value) {
+                    return 'No further details available';
+                }
+                return JSON.stringify(JSON.parse(value), null, 2);
+            }
+        }
+    };
+</script>

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -2,16 +2,12 @@
     <div>
         <button @click="getEvents">Events</button> |
         <button @click="getAdminEvents">Admin Events</button>
-        <ul>
-            <li v-for="(event, index) in events" :key="index">
-                {{event.niceDate}} | {{ event.type }} | {{ event.userId }} | {{event.details.username}}
-            </li>
-        </ul>
-        <ul>
-            <li v-for="(event, index) in adminEvents" :key="index">
-                {{event.niceDate}} | {{event.operationType}} | {{ event.resourceType }}
-            </li>
-        </ul>
+        <v-data-table
+                :headers="headers"
+                :items="events"
+                :items-per-page="5"
+                class="elevation-1"
+        ></v-data-table>
     </div>
 </template>
 
@@ -29,7 +25,13 @@
         data() {
             return {
                 events: [],
-                adminEvents: []
+                adminEvents: [],
+                headers: [
+                    { text: 'Time', value: 'readableDate'},
+                    { text: 'User', value: 'details.username' },
+                    { text: 'Event type', value: 'type' },
+                    { text: 'Application', value: 'clientId' },
+                ],
             }
         },
 
@@ -38,6 +40,7 @@
                 return EventsRepository.getEvents()
                     .then(response => {
                         this.events = response.data;
+                        this.events = this.events.filter(a => a.type === 'LOGIN');
                         for (let e of this.events) {
                             e.readableDate = formatDate(e.time);
                             if (!e.details) {

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -1,6 +1,10 @@
 <template>
     <div>
-        <button @click="getEvents">Refresh</button>
+        <v-text-field
+          v-model="search"
+          append-icon="mdi-magnify"
+          label="Search"
+        ></v-text-field>
         <v-data-table
                 :headers="headers"
                 :items="events"
@@ -8,7 +12,9 @@
                 class="elevation-1"
                 loading-text="Loading events"
                 :loading="loadingStatus"
+                :search="search"
         ></v-data-table>
+      <button @click="getEvents">Refresh</button>
     </div>
 </template>
 
@@ -24,6 +30,7 @@
         name: "EventLog",
         data() {
             return {
+                search: '',
                 loadingStatus: false,
                 events: [],
                 headers: [
@@ -46,7 +53,7 @@
                     .then(response => {
                         this.events = response.data;
                         // TODO What events should we show? All that are recorded? It might make sense not to. Perhaps we want full audit enabled on Keycloak, but the Access Team is only interested in (and understands) a smaller set of events.
-                        this.events = this.events.filter(a => a.type === 'LOGIN');
+                        // this.events = this.events.filter(a => a.type === 'LOGIN');
                         for (let e of this.events) {
                             e.readableDate = formatDate(e.time);
                             if (!e.details) {

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -1,5 +1,68 @@
 <template>
-  <div >
-      EVENT LOG
-  </div>
+    <div>
+        <button @click="getEvents">Events</button> |
+        <button @click="getAdminEvents">Admin Events</button>
+        <ul>
+            <li v-for="(event, index) in events" :key="index">
+                {{event.niceDate}} | {{ event.type }} | {{ event.userId }} | {{event.details.username}}
+            </li>
+        </ul>
+        <ul>
+            <li v-for="(event, index) in adminEvents" :key="index">
+                {{event.niceDate}} | {{event.operationType}} | {{ event.resourceType }}
+            </li>
+        </ul>
+    </div>
 </template>
+
+<script>
+    import {RepositoryFactory} from "./../api/RepositoryFactory";
+
+    const EventsRepository = RepositoryFactory.get("events");
+    const AdminEventsRepository = RepositoryFactory.get("adminEvents");
+
+    const options = {dateStyle: 'short', timeStyle: 'short'};
+    const formatDate = new Intl.DateTimeFormat(undefined, options).format;
+
+    export default {
+        name: "EventLog",
+        data() {
+            return {
+                events: [],
+                adminEvents: []
+            }
+        },
+
+        methods: {
+            getEvents: function () {
+                return EventsRepository.getEvents()
+                    .then(response => {
+                        this.events = response.data;
+                        for (let e of this.events) {
+                            e.readableDate = formatDate(e.time);
+                            if (!e.details) {
+                                e.details = 'no details';
+                            }
+                        }
+                    })
+                    .catch(e => {
+                        console.log(e);
+                        throw e;
+                    });
+            },
+            getAdminEvents: function () {
+                return AdminEventsRepository.getEvents()
+                    .then(response => {
+                        this.adminEvents = response.data;
+                        for (let e of this.adminEvents) {
+                            e.readableDate = formatDate(e.time);
+                        }
+                    })
+                    .catch(e => {
+                        console.log(e);
+                        throw e;
+                    });
+            }
+        }
+    };
+</script>

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -19,9 +19,7 @@
 </template>
 
 <script>
-    import {RepositoryFactory} from "./../api/RepositoryFactory";
-
-    const EventsRepository = RepositoryFactory.get("events");
+    import EventsRepository from "../api/EventsRepository";
 
     const options = {dateStyle: 'short', timeStyle: 'short'};
     const formatDate = new Intl.DateTimeFormat(undefined, options).format;
@@ -47,25 +45,20 @@
         },
 
         methods: {
-            getEvents: function () {
-                this.loadingStatus = true;
-                return EventsRepository.getEvents()
-                    .then(response => {
-                        this.events = response.data;
-                        // TODO What events should we show? All that are recorded? It might make sense not to. Perhaps we want full audit enabled on Keycloak, but the Access Team is only interested in (and understands) a smaller set of events.
-                        // this.events = this.events.filter(a => a.type === 'LOGIN');
-                        for (let e of this.events) {
-                            e.readableDate = formatDate(e.time);
-                            if (!e.details) {
-                                e.details = 'no details';
-                            }
-                        }
-                    })
-                    .catch(e => {
-                        console.log(e);
-                        throw e;
-                    })
-                    .finally(() => this.loadingStatus = false);
+            getEvents: async function () {
+              this.loadingStatus = true;
+              try {
+                let promise = await EventsRepository.getEvents();
+                this.events = promise.data;
+                for (let e of this.events) {
+                  e.readableDate = formatDate(e.time);
+                  if (!e.details) {
+                    e.details = 'no details';
+                  }
+                }
+              } finally {
+                this.loadingStatus = false;
+              }
             }
         }
     };


### PR DESCRIPTION
Add the "Events" and "Admin Events" views. 

On one hand this work is incomplete because we want to add more features, like user ID to username mapping, a more readable display of details (e.g. not JSON), and possibly filtering out events, but on the other hand this code is in a good state to be merged: it's working and has a sensible design to build on. 

If we review and merge this now, future pull requests to add the aforementioned features will be easier to review.