### PR TITLE
AB#750 Add username and client name look-up on Event Logs.

### DIFF
--- a/src/api/ClientsRepository.js
+++ b/src/api/ClientsRepository.js
@@ -6,10 +6,6 @@ export default {
     get() {
         return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}`));
     },
-
-    getClient(clientId) {
-        return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}/${clientId}`));
-    },
     
     getRoles(clientId){
         return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}/${clientId}/roles`));
@@ -26,19 +22,16 @@ export default {
      * @returns {Promise<void>}
      */
     async addClientNamesToEvents(events) {
+        const allClients = await this.get();
+        // Note clientResponse.data.clientId is not the numeric ID, it is actually a name.
+        // There is also a longer display name property ("name").
+        allClients.data.map((client) => sessionStorage[client.id] = client.clientId);
         for (let event of events) {
-            if (event.clientId && !sessionStorage[event.clientId]) {
-                try {
-                    const clientResponse = await this.getClient(event.clientId);
-                    // Note clientResponse.data.clientId is not the numeric ID, it is actually a name.
-                    // There is also a longer display name property ("name").
-                    sessionStorage[event.clientId] = clientResponse.data.clientId;
-                } catch (ex) {
-                    console.log(ex);
-                    sessionStorage[event.clientId] = 'no client found';
-                }
+            if (event.clientId && sessionStorage[event.clientId]) {
+                event.clientName = sessionStorage[event.clientId];
+            } else {
+                event.clientName = 'no client found';
             }
-            event.clientName = sessionStorage[event.clientId];
         }
     }
 

--- a/src/api/ClientsRepository.js
+++ b/src/api/ClientsRepository.js
@@ -25,7 +25,7 @@ export default {
      * @param events object array, objects should contain clientId property.
      * @returns {Promise<void>}
      */
-    async getClientNames(events) {
+    async addClientNamesToEvents(events) {
         for (let event of events) {
             if (event.clientId && !sessionStorage[event.clientId]) {
                 try {

--- a/src/api/ClientsRepository.js
+++ b/src/api/ClientsRepository.js
@@ -6,8 +6,40 @@ export default {
     get() {
         return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}`));
     },
+
+    getClient(clientId) {
+        return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}/${clientId}`));
+    },
     
     getRoles(clientId){
         return kcRequest().then(axiosInstance => axiosInstance.get(`${resource}/${clientId}/roles`));
+    },
+
+    /**
+     * Adds client names to the events array using the clientId to lookup the client name.
+     *
+     * The events array should contain objects with a clientId property.
+     * The client name will be added to the corresponding object. It caches
+     * the clientId:clientName in sessionStorage.
+     *
+     * @param events object array, objects should contain clientId property.
+     * @returns {Promise<void>}
+     */
+    async getClientNames(events) {
+        for (let event of events) {
+            if (event.clientId && !sessionStorage[event.clientId]) {
+                try {
+                    const clientResponse = await this.getClient(event.clientId);
+                    // Note clientResponse.data.clientId is not the numeric ID, it is actually a name.
+                    // There is also a longer display name property ("name").
+                    sessionStorage[event.clientId] = clientResponse.data.clientId;
+                } catch (ex) {
+                    console.log(ex);
+                    sessionStorage[event.clientId] = 'no client found';
+                }
+            }
+            event.clientName = sessionStorage[event.clientId];
+        }
     }
+
 }

--- a/src/api/UsersRepository.js
+++ b/src/api/UsersRepository.js
@@ -60,7 +60,7 @@ export default {
      * @param events object array, objects should contain userId property.
      * @returns {Promise<void>}
      */
-    async getUsernames(events) {
+    async addUsernamesToEvents(events) {
         for (let event of events) {
             if (!sessionStorage[event.userId]) {
                 try {

--- a/src/api/UsersRepository.js
+++ b/src/api/UsersRepository.js
@@ -48,5 +48,30 @@ export default {
         //Keycloak expects the roles that will be removed in the body of the request which Axios doesn't do by default
         const deleteContent = { data: content }
         return kcRequest().then(axiosInstance => axiosInstance.delete(`${resource}/${userId}/${clientRoleMappings}/${clientId}/`, deleteContent));
+    },
+
+    /**
+     * Adds usernames to the events array using the userId to lookup the username.
+     *
+     * The events array should contain objects with a userId property.
+     * The username will be added to the corresponding object. It caches
+     * the userId:username in sessionStorage.
+     *
+     * @param events object array, objects should contain userId property.
+     * @returns {Promise<void>}
+     */
+    async getUsernames(events) {
+        for (let event of events) {
+            if (!sessionStorage[event.userId]) {
+                try {
+                    const userData = await this.getUser(event.userId);
+                    sessionStorage[event.userId] = userData.data.username;
+                } catch (ex) {
+                    console.log(ex);
+                    sessionStorage[event.userId] = 'no user found';
+                }
+            }
+            event.username = sessionStorage[event.userId];
+        }
     }
 }

--- a/src/components/UserDetails.vue
+++ b/src/components/UserDetails.vue
@@ -6,7 +6,7 @@
       <v-row no-gutters>
         <v-col class="col-7">
           <v-form ref="form">
-            <label for="user-name" class="required">User Name</label>
+            <label for="user-name" class="required">Username</label>
             <v-text-field
               dense
               outlined

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -38,6 +38,7 @@
         >
             <template v-slot:expanded-item="{ headers, item }">
                 <td :colspan="headers.length">
+                  <pre>Data: {{item.representation | pretty}}</pre>
                   <pre>User ID: {{ item.userId }}</pre>
                   <pre>Client ID: {{ item.clientId }}</pre>
                 </td>

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -37,7 +37,10 @@
                 :search="filterEvents"
         >
             <template v-slot:expanded-item="{ headers, item }">
-                <td :colspan="headers.length"><pre>{{item.representation | pretty}}</pre></td>
+                <td :colspan="headers.length">
+                  <pre>User ID: {{ item.userId }}</pre>
+                  <pre>Client ID: {{ item.clientId }}</pre>
+                </td>
             </template>
 
         </v-data-table>
@@ -46,9 +49,11 @@
 </template>
 
 <script>
-    import AdminEventsRepository from "../api/AdminEventsRepository";
+import AdminEventsRepository from "../api/AdminEventsRepository";
+import UsersRepository from "../api/UsersRepository";
+import ClientsRepository from "../api/ClientsRepository";
 
-    const options = {dateStyle: 'short', timeStyle: 'short'};
+const options = {dateStyle: 'short', timeStyle: 'short'};
     const formatDate = new Intl.DateTimeFormat(undefined, options).format;
 
     export default {
@@ -67,8 +72,8 @@
                     { text: 'Time', value: 'readableDate'},
                     { text: 'Event type', value: 'operationType' },
                     { text: 'Resource type', value: 'resourceType' },
-                    { text: 'User', value: 'userId' },
-                    { text: 'Application', value: 'clientId' },
+                    { text: 'User', value: 'username' },
+                    { text: 'Application', value: 'clientName' },
                     { text: 'Details', value: 'data-table-expand' },
                 ],
             }
@@ -103,6 +108,8 @@
                   e.clientId = e.resourcePath.substring(65, 101);
                 }
               }
+              await ClientsRepository.getClientNames(this.adminEvents);
+              await UsersRepository.getUsernames(this.adminEvents);
             } finally {
               this.loadingStatus = false;
             }
@@ -119,6 +126,7 @@
             }
         }
     };
+
 
     function buildQueryParameters() {
       const params = new URLSearchParams();

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -1,34 +1,49 @@
 <template>
     <div>
+      <label for="user-id">User ID</label>
       <v-text-field
-          placeholder="User ID"
+          id="user-id"
+          dense
+          outlined
           v-model="searchUserId"
       />
+      <label for="app-id">Application ID</label>
       <v-text-field
-          placeholder="Application ID"
+          id="app-id"
+          dense
+          outlined
           v-model="searchClientId"
       />
+      <label for="from-date">Date (from)</label>
       <v-text-field
-          placeholder="Date (from)"
+          id="from-date"
+          dense
+          outlined        
           hint="yyyy-MM-dd"
           v-model="searchDateFrom"
       />
+      <label for="to-date">Date (to)</label>
       <v-text-field
-          placeholder="Date (to)"
+          id="to-date"
+          dense
+          outlined
           hint="yyyy-MM-dd"
           v-model="searchDateTo"
       />
       <v-btn id="search-button" class="secondary" medium @click.native="searchEvents">Search</v-btn>
+
+      <h1 style="margin-bottom: 10px;">Search Results</h1>
+
       <v-text-field
           v-model="filterEvents"
           append-icon="mdi-magnify"
-          label=" Search"
+          label=" Filter Results"
       ></v-text-field>
         <v-data-table
                 :headers="headers"
                 :items="adminEvents"
                 :items-per-page="15"
-                class="elevation-1"
+                class="base-table"
                 show-expand
                 :single-expand="singleExpand"
                 item-key="key"
@@ -147,3 +162,9 @@ const options = {dateStyle: 'short', timeStyle: 'short'};
       return params;
     }
 </script>
+
+<style scoped>
+#search-button {
+  margin: 0px 0px 25px 0px
+}
+</style>

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -109,8 +109,8 @@ const options = {dateStyle: 'short', timeStyle: 'short'};
                   e.clientId = e.resourcePath.substring(65, 101);
                 }
               }
-              await ClientsRepository.getClientNames(this.adminEvents);
-              await UsersRepository.getUsernames(this.adminEvents);
+              await ClientsRepository.addClientNamesToEvents(this.adminEvents);
+              await UsersRepository.addUsernamesToEvents(this.adminEvents);
             } finally {
               this.loadingStatus = false;
             }

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -37,7 +37,7 @@
       <v-text-field
         v-model="filterEvents"
         append-icon="mdi-magnify"
-        placeholder="Filter"
+        placeholder="Filter Results"
       ></v-text-field>
       <v-data-table
               :headers="headers"

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -108,7 +108,7 @@
                 e.details = 'no details';
               }
             }
-            await UsersRepository.getUsernames(this.events);
+            await UsersRepository.addUsernamesToEvents(this.events);
           } finally {
             this.loadingStatus = false;
           }

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -67,8 +67,7 @@
           events: [],
           headers: [
             {text: 'Time', value: 'readableDate'},
-            {text: 'User', value: 'userId'},
-            {text: 'Username', value: 'username'},
+            {text: 'User', value: 'username'},
             {text: 'Event type', value: 'type'},
             {text: 'Application', value: 'clientId'},
             {text: 'Details', value: 'data-table-expand'},

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -1,47 +1,62 @@
 <template>
     <div>
+      <label for="user-id">User ID</label>
       <v-text-field
-          placeholder="User ID"
+          id="user-id"
+          dense
+          outlined
           v-model="searchUserId"
       />
+      <label for="app-id">Application ID</label>
       <v-text-field
-          placeholder="Application"
-      v-model="searchApplication"
+          id="app-id"
+          dense
+          outlined
+          v-model="searchClientId"
       />
+      <label for="from-date">Date (from)</label>
       <v-text-field
-          placeholder="Date (from)"
-      hint="yyyy-MM-dd"
-      v-model="searchDateFrom"
+          id="from-date"
+          dense
+          outlined        
+          hint="yyyy-MM-dd"
+          v-model="searchDateFrom"
       />
+      <label for="to-date">Date (to)</label>
       <v-text-field
-          placeholder="Date (to)"
-      hint="yyyy-MM-dd"
-      v-model="searchDateTo"
+          id="to-date"
+          dense
+          outlined
+          hint="yyyy-MM-dd"
+          v-model="searchDateTo"
       />
       <v-btn id="search-button" class="secondary" medium @click.native="searchEvents">Search</v-btn>
-        <v-text-field
-          v-model="filterEvents"
-          append-icon="mdi-magnify"
-          placeholder="Filter"
-        ></v-text-field>
-        <v-data-table
-                :headers="headers"
-                :items="events"
-                :items-per-page="15"
-                class="elevation-1"
-                show-expand
-                :single-expand="singleExpand"
-                item-key="key"
-                loading-text="Loading events"
-                :loading="loadingStatus"
-                :search="filterEvents"
-        >
-          <template v-slot:expanded-item="{ headers, item }">
-            <td :colspan="headers.length">
-              <pre>User ID: {{ item.userId }}</pre>
-            </td>
-          </template>
-        </v-data-table>
+
+      <h1 style="margin-bottom: 10px;">Search Results</h1>
+
+      <v-text-field
+        v-model="filterEvents"
+        append-icon="mdi-magnify"
+        placeholder="Filter"
+      ></v-text-field>
+      <v-data-table
+              :headers="headers"
+              :items="events"
+              :items-per-page="15"
+              class="base-table"
+              show-expand
+              :single-expand="singleExpand"
+              item-key="key"
+              loading-text="Loading events"
+              :loading="loadingStatus"
+              :search="filterEvents"
+      >
+        <template v-slot:expanded-item="{ headers, item }">
+          <td :colspan="headers.length">
+            <pre>User ID: {{ item.userId }}</pre>
+          </td>
+        </template>
+      </v-data-table>
       <button @click="getAllEvents">Refresh</button>
     </div>
 </template>
@@ -116,3 +131,9 @@
       }
     }
 </script>
+
+<style scoped>
+#search-button {
+  margin: 0px 0px 25px 0px
+}
+</style>


### PR DESCRIPTION
[AB#750](https://dev.azure.com/cyrovalente/14004b17-200a-4897-9dd5-d44e111f33a1/_workitems/edit/750) Add username and client name look-up on Event Logs.

This shows usernames and client names on the Event Logs. It needs to look up the names using the Keycloak REST API using the user IDs and client IDs. To avoid extra lookups, it caches the results in `sessionStorage`.

Note that the user now needs the `view-clients` role in order to look up client names. This could have been done with the existing `query-clients` role but this a bit easier and more consistent with the username lookup which also looks up a single user to get the username. I just realized this also exposes the client secrets though, which seems excessive when I can probably avoid it by sticking to the `query-clients` role. I'll add it to the list of things to change.

There is a lot left to do in Event Logs I think. I'll show my list here just so you know what I'm thinking:
* Search by username, not just ID.
* Search by client name, not just ID.
* Display errors, don't just log them.
* Username and client name lookup should be done concurrently in batches; not one at a time.
* Possible bug: if you conduct a search while viewing page N of the previous search results, it seems to stay on page N even if the page no longer exists in the new results.
* Security: should use the `query-clients` role, not the `view-clients` role. The latter exposes the client secret.

All this said, I think the code remains good quality and functional, and therefore worthy of merging at this stage in the project.