### PR TITLE
added configurable logout redirect url

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,4 @@
+{
+  "idps_to_show": "idir,moh_idp",
+  "siteminder_logout": "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=localhost:8080"
+}

--- a/src/components/template/TheHeader.vue
+++ b/src/components/template/TheHeader.vue
@@ -19,7 +19,7 @@ export default {
     name: "TheHeader",
     methods: {
     logout: function () {
-      this.$keycloak.logout();
+      this.$keycloak.logout({redirectUri: this.$config.siteminder_logout});
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -8,14 +8,20 @@ import keycloak from './keycloak';
 import store from './store'
 
 Vue.config.productionTip = false
-
 Vue.prototype.$keycloak = keycloak; //maybe be able to remove this and use the export
 
 keycloak.onAuthSuccess = function () {
-  new Vue({
-    vuetify,
-    router,
-    store,
-    render: h => h(App)
-  }).$mount('#app');
+    fetch(process.env.BASE_URL + "config.json")
+        .then((response) => {
+            return response.json();
+        })
+        .then((config) => {
+                Vue.prototype.$config = config
+                new Vue({
+                    vuetify,
+                    router,
+                    store,
+                    render: h => h(App)
+                }).$mount('#app');
+        })
 }


### PR DESCRIPTION
Confirmed changing the values in `config.json` on the webserver picks up at runtime
We should be able to use this same approach to make `idps_to_show` configurable (still TBD if we just want to use kc_idp_hint instead though)