### PR TITLE
Use Vue CLI development mode to show Keycloak tools and all IDPs only when running locally.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,8 +7,8 @@
         <alert/>
         <router-view></router-view>
       </section>
-      <v-checkbox v-model="showKeycloakTools" :label="`Keycloak Dev Tools`"></v-checkbox>
-      <KeycloakDevTools v-show="showKeycloakTools" />
+      <v-checkbox v-model="showKeycloakTools" :label="`Keycloak Dev Tools`" v-if="vueCliMode === 'development'"></v-checkbox>
+      <KeycloakDevTools v-if="showKeycloakTools" />
     </main>
     <the-footer></the-footer>
   </v-app>
@@ -33,6 +33,7 @@ export default {
   },
   data() {
     return {
+      vueCliMode: process.env.NODE_ENV,
       showKeycloakTools: false
     };
   },

--- a/src/keycloak/index.js
+++ b/src/keycloak/index.js
@@ -15,7 +15,9 @@ let initOptions = {
 // https://stackoverflow.com/a/56338011/201891
 let kcLogin = keycloak.login;
 keycloak.login = (options) => {
-    options.idpHint = 'idir';
+    if (process.env.NODE_ENV !== 'development') {
+        options.idpHint = 'idir';
+    }
     return kcLogin(options);
 };
 


### PR DESCRIPTION
Use Vue CLI "development" mode to show Keycloak tools and all IDPs only when running locally.

Trevor this works fine for me, but could you please try it out on development/test. The extent of my testing was to add a typo to the string comparison (e.g. `dddevelopment`), but I can't test it on other environments without your help.

This doesn't make the build artifact different, it just uses the NODE_ENV environment variable like is already used in `vue.config.js`.