### PR TITLE
AB#1271 Search User History by Administrator ID.

### DIFF
--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -16,6 +16,13 @@
             outlined
             v-model="searchClientId"
         />
+        <label for="admin-id">Administrator ID</label>
+        <v-text-field
+            id="admin-id"
+            dense
+            outlined
+            v-model="searchAdministratorId"
+        />
         <label for="from-date">Date (from)</label>
         <v-text-field
             id="from-date"
@@ -83,6 +90,7 @@ const options = {dateStyle: 'short', timeStyle: 'short'};
             return {
                 searchUserId: '',
                 searchClientId: '',
+                searchAdministratorId: '',
                 searchDateFrom: '',
                 searchDateTo: '',
                 filterEvents: '',
@@ -159,6 +167,9 @@ const options = {dateStyle: 'short', timeStyle: 'short'};
         params.append('resourcePath', `users/${this.searchUserId}*`);
       } else if (this.searchClientId) {
         params.append('resourcePath', `*role-mappings/clients/${this.searchClientId}*`);
+      }
+      if (this.searchAdministratorId) {
+        params.append('authUser', this.searchAdministratorId);
       }
       [
         {name: 'dateFrom', value: this.searchDateFrom},

--- a/tests/e2e/alltests.js
+++ b/tests/e2e/alltests.js
@@ -54,7 +54,6 @@ test('Test update user role', async t => {
     await t
         .typeText('#user-search', 'testcafe')
         .click('#search-button')
-        // This is the ID of the testcafe user.
         .click(Selector('td').withText(TEST_CAFE_USER_ID))
         .typeText('#select-client', client, { replace: true })
         .click(Selector('.v-list-item').withText('realm-management'))
@@ -62,6 +61,15 @@ test('Test update user role', async t => {
         .click('#save-user-roles')
         .expect(Selector('#primary-alert').textContent)
         .contains('Roles updated successfully');
+});
+
+test('Test search by administrator', async t => {
+    await t
+        .click('#admin-event-log-link')
+        .typeText('#admin-id', TEST_CAFE_USER_ID)
+        .pressKey('enter')
+        .expect(Selector('html').textContent)
+        .contains('Test Cafe Cafe');
 });
 
 


### PR DESCRIPTION
Hi Trevor,

I decided it would be worthwhile to at least replicate what's possible in the Keycloak Admin Console. It's basically free, and it could be useful. You can get the Admin ID out of the "Details" of an Event, or from the User Search screen.