### PR TITLE
Fix bug with pagination and expanded details on the audit tabs.

### DIFF
--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -147,9 +147,7 @@ const options = {dateStyle: 'short', timeStyle: 'short'};
               await UsersRepository.addAdminNamesToEvents(this.adminEvents);
             } finally {
               this.loadingStatus = false;
-              // The Vuetify data-table component keeps track of the current page and which records are "expanded", so
-              // if there are new search results, reset "pageValue" and "expandedValues". I think this actually
-              // indicates a bug in the data-table component, as the data-table in UserSearch.vue doesn't require resetting.
+              // https://github.com/vuetifyjs/vuetify/issues/10949
               this.pageValue = 1;
               this.expandedValues = [];
             }

--- a/src/views/AdminEventLog.vue
+++ b/src/views/AdminEventLog.vue
@@ -61,6 +61,8 @@
                 loading-text="Loading events"
                 :loading="loadingStatus"
                 :search="filterEvents"
+                :page.sync="pageValue"
+                :expanded.sync="expandedValues"
         >
             <template v-slot:expanded-item="{ headers, item }">
                 <td :colspan="headers.length">
@@ -106,6 +108,8 @@ const options = {dateStyle: 'short', timeStyle: 'short'};
                     { text: 'Application', value: 'clientName' },
                     { text: 'Details', value: 'data-table-expand' },
                 ],
+                pageValue: 1,
+                expandedValues: [],
             }
         },
 
@@ -143,6 +147,11 @@ const options = {dateStyle: 'short', timeStyle: 'short'};
               await UsersRepository.addAdminNamesToEvents(this.adminEvents);
             } finally {
               this.loadingStatus = false;
+              // The Vuetify data-table component keeps track of the current page and which records are "expanded", so
+              // if there are new search results, reset "pageValue" and "expandedValues". I think this actually
+              // indicates a bug in the data-table component, as the data-table in UserSearch.vue doesn't require resetting.
+              this.pageValue = 1;
+              this.expandedValues = [];
             }
 
           }

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -53,6 +53,8 @@
               loading-text="Loading events"
               :loading="loadingStatus"
               :search="filterEvents"
+              :page.sync="pageValue"
+              :expanded.sync="expandedValues"
       >
         <template v-slot:expanded-item="{ headers, item }">
           <td :colspan="headers.length">
@@ -90,6 +92,8 @@
             {text: 'Application', value: 'clientId'},
             {text: 'Details', value: 'data-table-expand'},
           ],
+          pageValue: 1,
+          expandedValues: [],
         }
       },
 
@@ -129,6 +133,11 @@
             await UsersRepository.addUsernamesToEvents(this.events);
           } finally {
             this.loadingStatus = false;
+            // The Vuetify data-table component keeps track of the current page and which records are "expanded", so
+            // if there are new search results, reset "pageValue" and "expandedValues". I think this actually
+            // indicates a bug in the data-table component, as the data-table in UserSearch.vue doesn't require resetting.
+            this.pageValue = 1;
+            this.expandedValues = [];
           }
         }
       }

--- a/src/views/EventLog.vue
+++ b/src/views/EventLog.vue
@@ -133,9 +133,7 @@
             await UsersRepository.addUsernamesToEvents(this.events);
           } finally {
             this.loadingStatus = false;
-            // The Vuetify data-table component keeps track of the current page and which records are "expanded", so
-            // if there are new search results, reset "pageValue" and "expandedValues". I think this actually
-            // indicates a bug in the data-table component, as the data-table in UserSearch.vue doesn't require resetting.
+            // https://github.com/vuetifyjs/vuetify/issues/10949
             this.pageValue = 1;
             this.expandedValues = [];
           }


### PR DESCRIPTION
# Pagination bug

To reproduce this bug on the existing application, go to one of the audit tabs. Let the default search run. Then advance the search results to the last page. Then run another search that should return limited results. The search results will remain on the last page, even if there are no results on that page.

# Expand details bug

To reproduce this bug, go to one of the audit tabs. Let the default search run. Expand the details of one of the records in the search results. Run another search. The details of the record you chose, by index, will remain expanded.