### PR TITLE
Convert application from Spring WebFlux to Spring MVC.

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,6 +25,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
@@ -44,10 +48,9 @@
         <!-- open api and swagger documentation -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-webflux-ui</artifactId>
-            <version>1.4.8</version>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.5.0</version>
         </dependency>
-
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
@@ -49,6 +49,8 @@ public class UsersController {
     @GetMapping("/users/{id}")
     public Mono<Object> users(@PathVariable String id) {
         String path = usersPath + "/" + id;
-        return webClientService.get(path, null);
+        Mono<Object> mono = webClientService.get(path, null);
+        Object data = mono.block();
+        return mono;
     }
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/security/SecurityConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/security/SecurityConfig.java
@@ -1,16 +1,15 @@
 package ca.bc.gov.hlth.mohums.security;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
-import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
-import org.springframework.security.web.server.SecurityWebFilterChain;
-import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 
-@EnableWebFluxSecurity
-public class SecurityConfig {
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Value("${user-management-client.roles.view-clients}")
     private String viewClientsRole;
@@ -21,25 +20,23 @@ public class SecurityConfig {
     @Value("${user-management-client.roles.view-users}")
     private String viewUsersRole;
 
-    @Bean
-    public SecurityWebFilterChain securityWebFilterChain(final ServerHttpSecurity http) {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
 
         final JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
         jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(new KeycloakClientRoleConverter());
 
         http
-            .securityMatcher(ServerWebExchangeMatchers.pathMatchers("/**"))
-            .authorizeExchange()
-                .pathMatchers("/docs/**").permitAll()
-                .pathMatchers("/clients/**").hasRole(viewClientsRole)
-                .pathMatchers("/groups/**").hasRole(viewGroupsRole)
-                .pathMatchers("/users/**").hasRole(viewUsersRole)
-                .pathMatchers("/*").denyAll()
-            .anyExchange().authenticated().and()
+                .authorizeRequests()
+                .mvcMatchers("/docs/**").permitAll()
+                .mvcMatchers("/clients/**").hasRole(viewClientsRole)
+                .mvcMatchers("/groups/**").hasRole(viewGroupsRole)
+                .mvcMatchers("/users/**").hasRole(viewUsersRole)
+                .mvcMatchers("/*").denyAll()
+                .and()
             .oauth2ResourceServer().jwt()
-            .jwtAuthenticationConverter(new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter));
+            .jwtAuthenticationConverter(jwtAuthenticationConverter);
 
-        return http.build();
     }
 
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
@@ -31,10 +31,7 @@ public class WebClientConfig {
 
         OAuth2AuthorizedClientProvider authorizedClientProvider =
                 OAuth2AuthorizedClientProviderBuilder.builder()
-                        .authorizationCode()
-                        .refreshToken()
                         .clientCredentials()
-                        .password()
                         .build();
 
         DefaultOAuth2AuthorizedClientManager authorizedClientManager =

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
@@ -5,13 +5,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.DefaultReactiveOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServerOAuth2AuthorizedClientExchangeFilterFunction;
-import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -25,31 +25,33 @@ public class WebClientConfig {
     private String keycloakAdminBaseUrl;
 
     @Bean
-    public ReactiveOAuth2AuthorizedClientManager authorizedClientManager(
-            final ReactiveClientRegistrationRepository clientRegistrationRepository,
-            final ServerOAuth2AuthorizedClientRepository authorizedClientRepository) {
+    public OAuth2AuthorizedClientManager authorizedClientManager(
+            ClientRegistrationRepository clientRegistrationRepository,
+            OAuth2AuthorizedClientRepository authorizedClientRepository) {
 
-        ReactiveOAuth2AuthorizedClientProvider authorizedClientProvider
-                = ReactiveOAuth2AuthorizedClientProviderBuilder.builder()
+        OAuth2AuthorizedClientProvider authorizedClientProvider =
+                OAuth2AuthorizedClientProviderBuilder.builder()
+                        .authorizationCode()
+                        .refreshToken()
                         .clientCredentials()
+                        .password()
                         .build();
 
-        DefaultReactiveOAuth2AuthorizedClientManager authorizedClientManager
-                = new DefaultReactiveOAuth2AuthorizedClientManager(clientRegistrationRepository,
-                        authorizedClientRepository);
-
+        DefaultOAuth2AuthorizedClientManager authorizedClientManager =
+                new DefaultOAuth2AuthorizedClientManager(
+                        clientRegistrationRepository, authorizedClientRepository);
         authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
 
         return authorizedClientManager;
     }
 
     @Bean("kcAuthorizedWebClient")
-    public WebClient webClient(ReactiveOAuth2AuthorizedClientManager authorizedClientManager) {
+    public WebClient webClient(OAuth2AuthorizedClientManager authorizedClientManager) {
 
         String registrationId = "keycloak";
 
-        ServerOAuth2AuthorizedClientExchangeFilterFunction oauth
-                = new ServerOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
+        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth =
+                new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
         oauth.setDefaultClientRegistrationId(registrationId);
 
         return WebClient.builder()


### PR DESCRIPTION
This converts the application from a Spring WebFlux application to a Spring MVC application.

The advantages to doing so are explained in [Spring's documentation](https://docs.spring.io/spring-framework/docs/current/reference/html/web-reactive.html#webflux-framework-choice). For me, the most persuasive points are:

* Imperative programming is the easiest way to write, understand, and debug code. You have maximum choice of libraries, since, historically, most are blocking.
* If you have a large team, keep in mind the steep learning curve in the shift to non-blocking, functional, and declarative programming. A practical way to start without a full switch is to use the reactive WebClient.

One great thing about this is **the code hardly changes**. We change some dependencies, but the structure is the same. The RestControllers don't need to be modified at all.