### PR TITLE
UMC use UMS "create user" endpoint.

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/security/SecurityConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 @EnableWebSecurity
 @Configuration
@@ -61,6 +62,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOrigin(allowedOrigins);
         configuration.addAllowedHeader("*");
+        configuration.setExposedHeaders(Collections.singletonList("Location"));
         configuration.setAllowedMethods(Arrays.asList("GET","POST"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ user-management-client:
     view-users: view-users
     manage-users: manage-users
 config:
-  vanity-hostname: localhost
+  vanity-hostname: "http://localhost:9090"
   allowed-origins: "http://localhost:8080"
 spring:
   security:
@@ -44,3 +44,8 @@ server:
 #    key-store-type: pkcs12
 #    key-alias: localhost
 #    key-password: password
+#logging:
+#  level:
+#    KC_WEB_CLIENT: DEBUG
+#    org.apache.coyote.http11.Http11InputBuffer: DEBUG
+#    root: DEBUG

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ user-management-client:
     view-users: view-users
     manage-users: manage-users
 config:
-  vanity-hostname: "http://localhost:9090"
+  vanity-hostname: "http://localhost:${server.port}"
   allowed-origins: "http://localhost:8080"
 spring:
   security:

--- a/backend/src/test/java/ca/bc/gov/hlth/mohums/controller/UsersControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/mohums/controller/UsersControllerTest.java
@@ -10,7 +10,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class UsersControllerTest {
 
-    private final UsersController u = new UsersController(null, "localhost");
+    private final UsersController u = new UsersController(null, vanityHostname);
+
+    private static final String vanityHostname = "http://localhost";
 
     @Test
     void testNull() {
@@ -41,7 +43,7 @@ class UsersControllerTest {
         httpHeaders.setLocation(URI.create("https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms/moh_applications/users/d862b0ee-1e3f-423b-a200-55f2e8f103d9"));
         HttpHeaders newHeaders = u.convertLocationHeader(httpHeaders);
         assertNotNull(newHeaders);
-        assertEquals("https://localhost/users/d862b0ee-1e3f-423b-a200-55f2e8f103d9", newHeaders.getLocation().toASCIIString());
+        assertEquals(vanityHostname + "/users/d862b0ee-1e3f-423b-a200-55f2e8f103d9", newHeaders.getLocation().toASCIIString());
     }
 
     @Test

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -19,7 +19,7 @@ export default {
     },
 
     createUser(content) {
-        return kcRequest().then(axiosInstance => axiosInstance.post(`${resource}`, content));
+        return umsRequest().then(axiosInstance => axiosInstance.post(`${resource}`, content));
     },
 
     updateUser(userId, content) {


### PR DESCRIPTION
I forgot to include the "create user" endpoint in the pull request last week, the one for "Configure UMC to use UMS."

UMC use UMS "create user" endpoint. 
Fix bug in Location header conversion. 
Add Location header to allowed CORS response headers.