### PR TITLE
Ab#2225 user update loading indicator

### DIFF
--- a/frontend/src/components/UserUpdate.vue
+++ b/frontend/src/components/UserUpdate.vue
@@ -1,12 +1,24 @@
 <!--suppress XmlInvalidId -->
 <template>
-  <div id="user-info" v-show="user.username">
-    <h1>Update - {{ user.username }}</h1>
-    <user-details :userId="this.$route.params.userid" ref="userDetails">
-      <v-btn id="submit-button" class="secondary" medium v-on:click.prevent="updateUser">Update User</v-btn>
-    </user-details>
-    <user-update-roles :userId="this.$route.params.userid"></user-update-roles>
-    <user-update-groups :userId="this.$route.params.userid"></user-update-groups>
+  <div>
+
+    <v-skeleton-loader
+        :loading="loading"
+        v-show="!user.username"
+        ref="skeleton"
+        :boilerplate="boilerplate"
+        tile="true"
+        type="article, button"
+    >
+    </v-skeleton-loader>
+    <div id="user-info" v-show="user.username">
+      <h1>Update - {{ user.username }}</h1>
+      <user-details :userId="this.$route.params.userid" ref="userDetails">
+        <v-btn id="submit-button" class="secondary" medium v-on:click.prevent="updateUser">Update User</v-btn>
+      </user-details>
+      <user-update-roles :userId="this.$route.params.userid"></user-update-roles>
+      <user-update-groups :userId="this.$route.params.userid"></user-update-groups>
+    </div>
   </div>
 </template>
 
@@ -23,6 +35,13 @@ export default {
     UserUpdateGroups,
     UserDetails,
     UserUpdateRoles
+  },
+  data() {
+    return {
+      loading: true,
+      boilerplate: false,
+      type: 'list-item-avatar-three-line',
+    }
   },
   methods: {
     updateUser: function() {

--- a/frontend/src/components/UserUpdate.vue
+++ b/frontend/src/components/UserUpdate.vue
@@ -2,11 +2,9 @@
 <template>
   <div>
     <v-skeleton-loader
-        :loading="loading"
-        v-show="!user.username"
         ref="skeleton"
-        :boilerplate="boilerplate"
         tile="true"
+        v-show="!user.username"
         type="article, button, article"
     >
     </v-skeleton-loader>
@@ -34,12 +32,6 @@ export default {
     UserUpdateGroups,
     UserDetails,
     UserUpdateRoles
-  },
-  data() {
-    return {
-      loading: true,
-      boilerplate: false,
-    }
   },
   methods: {
     updateUser: function() {
@@ -78,3 +70,8 @@ export default {
   }
 };
 </script>
+<style>
+.v-skeleton-loader__button {
+  margin-left: 16px;
+}
+</style>

--- a/frontend/src/components/UserUpdate.vue
+++ b/frontend/src/components/UserUpdate.vue
@@ -1,14 +1,13 @@
 <!--suppress XmlInvalidId -->
 <template>
   <div>
-
     <v-skeleton-loader
         :loading="loading"
         v-show="!user.username"
         ref="skeleton"
         :boilerplate="boilerplate"
         tile="true"
-        type="article, button"
+        type="article, button, article"
     >
     </v-skeleton-loader>
     <div id="user-info" v-show="user.username">
@@ -40,7 +39,6 @@ export default {
     return {
       loading: true,
       boilerplate: false,
-      type: 'list-item-avatar-three-line',
     }
   },
   methods: {


### PR DESCRIPTION
https://dev.azure.com/cyrovalente/IAM%20Project/_workitems/edit/2225/

A loading screen is shown after selecting a user in the search results. Previously the content area would be completely blank until the content was loaded. The loading screen looks like this. There is also a nice animation.

![image](https://user-images.githubusercontent.com/1767127/107603917-31ab7300-6be3-11eb-829c-1e051b53cd1e.png)

The structure of the grey boxes, the "skeleton", is actually determined by the `type="article, button, article"` attribute on the component. Lots of different arrangements are possible: https://v2.vuetifyjs.com/en/components/skeleton-loaders/. I chose this one because it kind of corresponds to the page layout: content, button, content. In the layout I've specified the button is misaligned, but I can't change that without delving into the CSS.