### PR TITLE
AB#2846 Search results can be opened in a new tab.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 node_modules
-/dist
+/frontend/dist/
 
 # local env files
 .env.local

--- a/frontend/src/components/UserSearch.vue
+++ b/frontend/src/components/UserSearch.vue
@@ -23,7 +23,7 @@
           dense
           v-model="userSearchInput"
           placeholder="Username, email, name, or ID"
-          @keyup.native.enter="searchUser"
+          @keyup.enter="searchUser('&search='+userSearchInput)"
         />
       </v-col>
       <v-col class="col-4">
@@ -171,6 +171,13 @@
           loading-text="Searching for users"
           v-on:click:row="selectUser"
         >
+          <!-- https://stackoverflow.com/questions/61394522/add-hyperlink-in-v-data-table-vuetify -->
+          <template #item.username="{ item }">
+            <a target="_blank" :href="`#/users/${item.id}`" v-on:click="openNewTab">
+              {{ item.username }}
+            </a>
+            <v-icon small>mdi-open-in-new</v-icon>
+          </template>
           <template v-if="searchResults.length > 0" v-slot:footer>
             <v-toolbar flat>
               <v-spacer/>
@@ -221,7 +228,8 @@ export default {
       organizationInput: "",
       searchResults: [],
       userSearchLoadingStatus: false,
-      advancedSearchSelected: false
+      advancedSearchSelected: false,
+      newTab: false
     };
   },
   async created() {
@@ -248,7 +256,14 @@ export default {
     }
   },
   methods: {
+    openNewTab: function() {
+      this.newTab = true;
+    },
     selectUser: function(user) {
+      if (this.newTab) {
+        this.newTab = false;
+        return;
+      }
       this.$store.commit("alert/dismissAlert");
       this.$router.push({ name: "UserUpdate", params: { userid: user.id } });
     },

--- a/frontend/src/views/Users.vue
+++ b/frontend/src/views/Users.vue
@@ -1,5 +1,7 @@
 <template>
   <div >
+    <keep-alive include="UserSearch">
       <router-view></router-view>
+    </keep-alive>
   </div>
 </template>


### PR DESCRIPTION
Search results can now be opened in a new tab by clicking the Username in the Search Results. The icon I used to indicate this functionality is a classic icon used by Outlook, Gmail, and other programs to indicate that the item will be opened in a new window or tab. 

![image](https://user-images.githubusercontent.com/1767127/115335710-9b4f7c80-a152-11eb-9992-b76c757de1d4.png)

Also fix bug in Basic Search. Pressing "Enter" key to run search wasn't working.

Also save UserSearch component during Vue router navigation to restore search results on Back button.