### PR TITLE
5454 test new builds are working 2

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/util/FilterUserByOrgId.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/util/FilterUserByOrgId.java
@@ -81,7 +81,7 @@ public final class FilterUserByOrgId implements Predicate<Object> {
             // These exceptions are thrown when the value found by EXPRESSION
             // is not a valid JSON object. We can't stop people from creating
             // 'org_details' attributes that don't contain JSON data.
-            LOGGER.warn("Unable to parse: \"{}\": {}.", organizationDetails, e);
+            LOGGER.warn("Unable to parse: \"{}\": {}.", organizationDetails, e.getMessage());
         }
 
         return id;

--- a/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
@@ -176,8 +176,8 @@ public class MoHUmsIntegrationTests {
                         uriBuilder -> uriBuilder
                                 .path("/users")
                                 .queryParam("org", "00000010")
-                                .queryParam("first", "0")
-                                .queryParam("max", "10000")
+                                .queryParam("first", 0)
+                                .queryParam("max", 5000)
                                 .build()
                 )
                 .header("Authorization", "Bearer " + jwt)
@@ -266,8 +266,8 @@ public class MoHUmsIntegrationTests {
                 .uri(
                         uriBuilder -> uriBuilder
                                 .path("/users")
-                                .queryParam("first", "0")
-                                .queryParam("max", "2000")
+                                .queryParam("first", 0)
+                                .queryParam("max", 2000)
                                 .queryParam("lastLogBefore",
                                         LocalDate.now().format(DateTimeFormatter.ISO_DATE))
                                 .build()
@@ -293,8 +293,8 @@ public class MoHUmsIntegrationTests {
                 .uri(
                         uriBuilder -> uriBuilder
                                 .path("/users")
-                                .queryParam("first", "0")
-                                .queryParam("max", "2000")
+                                .queryParam("first", 0)
+                                .queryParam("max", 2000)
                                 .queryParam("firstName", "Trevor")
                                 .queryParam("lastLogAfter",
                                         LocalDate.now().minusMonths(1).format(DateTimeFormatter.ISO_DATE))
@@ -617,7 +617,7 @@ public class MoHUmsIntegrationTests {
                         uriBuilder -> uriBuilder
                                 .path("/" + resource)
                                 .queryParam("first", 0)
-                                .queryParam("max", 10_000)
+                                .queryParam("max", 5000)
                                 .build()
                 )
                 .header("Authorization", "Bearer " + jwt)


### PR DESCRIPTION
Reduce max getAll results (10000 -> 5000) which makes clientsAuthorized pass regularly when running full test suite post-Keycloak 15.0.2 upgrade; Log only exception message instead of full stacktrace for warning