### PR TITLE
Ab#7777#7826 bug fixes

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/validator/PermissionsValidator.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/validator/PermissionsValidator.java
@@ -14,8 +14,8 @@ public class PermissionsValidator {
     private String manageAllGroupsRole;
     public boolean validateGroupManagementPermission(Jwt requesterToken, String groupId){
         if(!canManageAllGroups(requesterToken)){
-            List<String> a = JwtTokenUtils.getUserGroups(requesterToken);
-            return a.contains(groupId);
+            List<String> userGroups = JwtTokenUtils.getUserGroups(requesterToken);
+            return userGroups.contains(groupId);
         }
         return true;
     }

--- a/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
@@ -316,7 +316,7 @@ public class MoHUmsIntegrationTests {
                                 .path("/users")
                                 .queryParam("first", 0)
                                 .queryParam("max", 2000)
-                                .queryParam("firstName", "Trevor")
+                                .queryParam("firstName", "Filip")
                                 .queryParam("lastLogAfter",
                                         LocalDate.now().minusMonths(1).format(DateTimeFormatter.ISO_DATE))
                                 .build()

--- a/frontend/src/components/UserUpdateGroups.vue
+++ b/frontend/src/components/UserUpdateGroups.vue
@@ -63,17 +63,6 @@ export default {
       const isPartOfGroup = this.ownGroups.some(group => group.name === groupName);
       return canManageOwnGroups && !isPartOfGroup;
     },
-    deleteDuplicateGroups: function(groups){
-      const uniqueGroupIds = [];
-      return groups.filter(group => {
-          const isDuplicate = uniqueGroupIds.includes(group.id);
-          if(!isDuplicate){
-            uniqueGroupIds.push(group.id);
-            return true;
-          }
-          return false;
-        });
-    },
     checkAdminPermissions: function() {
       if(this.$keycloak.tokenParsed.resource_access['USER-MANAGEMENT-SERVICE']?.roles.includes(this.MANAGE_ALL_GROUPS)){
         this.adminRole = this.MANAGE_ALL_GROUPS;
@@ -104,10 +93,8 @@ export default {
       if(this.adminRole === this.MANAGE_ALL_GROUPS){
         this.allGroups.push(...allGroups);
       }else if(this.adminRole === this.MANAGE_OWN_GROUPS){
-        const ownGroups = allGroups.filter(group => this.$keycloak.tokenParsed.groups?.some(name => name === group.name));
-        const uniqueCombinedGroups = this.deleteDuplicateGroups([...ownGroups, ...searchedUserGroups]);
-    
-        this.allGroups.push(...uniqueCombinedGroups);
+        const ownGroups = allGroups.filter(group => this.$keycloak.tokenParsed.groups?.some(name => name === group.name));    
+        this.allGroups.push(...ownGroups);
         this.ownGroups.push(...ownGroups);
       }else {
         this.allGroups.push(...searchedUserGroups);


### PR DESCRIPTION
Tooltip bug fix:
not an actual fix, but we're not displaying groups that user doesn't have access to anymore.

Advanced search bug:
bug because of SQL statement execution order.
SQL to test changes out, should return two different results if user is _falsely_ inactive.
```
SELECT USER_ID, MAX(ee.EVENT_TIME)
FROM KEYCLOAK.EVENT_ENTITY ee
WHERE ee."TYPE"='LOGIN' 
	AND ee.USER_ID='put_some_user_id_here' 
	AND event_time > (SYSDATE-365-TO_DATE('1970-01-01','YYYY-MM-DD'))*24*60*60*1000
GROUP BY USER_ID 
HAVING MAX(ee.EVENT_TIME) < 1663826400000
```
		
		
```
SELECT USER_ID, MAX(ee.EVENT_TIME)
FROM KEYCLOAK.EVENT_ENTITY ee
WHERE ee."TYPE"='LOGIN' 
	AND ee.USER_ID='put_some_user_id_here' 
	AND event_time > (SYSDATE-365-TO_DATE('1970-01-01','YYYY-MM-DD'))*24*60*60*1000
	AND event_time < 1663826400000
GROUP BY USER_ID 
```