### PR TITLE
reset linked identity types

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
@@ -5,10 +5,10 @@ import ca.bc.gov.hlth.mohums.util.AuthorizedClientsParser;
 import ca.bc.gov.hlth.mohums.util.FilterUserByOrgId;
 import ca.bc.gov.hlth.mohums.validator.PermissionsValidator;
 import ca.bc.gov.hlth.mohums.webclient.WebClientService;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,8 +27,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.springframework.http.HttpStatus;
 
 @RestController
 public class UsersController {
@@ -337,6 +335,11 @@ public class UsersController {
                                                    @AuthenticationPrincipal Jwt jwt) {
         return permissionsValidator.validateGroupManagementPermission(jwt, groupName) ?
                 webClientService.removeUserGroups(userId, groupId) : ResponseEntity.status(HttpStatus.FORBIDDEN).body("Remove user from group - permission denied");
+    }
+
+    @DeleteMapping("/users/{userId}/federated-identity/{identityProvider}")
+    public ResponseEntity<Object> removeUserIdentityProviderLinks(@PathVariable String userId, @PathVariable String identityProvider, @RequestBody String userIdIdpRealm){
+        return webClientService.removeUserIdentityProviderLink(userId, identityProvider, userIdIdpRealm);
     }
 
     private static final Pattern patternGuid = Pattern.compile(".*/users/(.{8}-.{4}-.{4}-.{4}-.{12})");

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/util/JwtTokenUtils.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/util/JwtTokenUtils.java
@@ -12,19 +12,19 @@ public class JwtTokenUtils {
     private static final String API_CLIENT_NAME = "USER-MANAGEMENT-SERVICE";
     private static final String RESOURCE_ACCESS_CLAIM = "resource_access";
 
-    public static List<String> getUserGroups(Jwt jwt){
-       return jwt.containsClaim(GROUPS_CLAIM) ? (List<String>) jwt.getClaims().get(GROUPS_CLAIM) : List.of();
+    public static List<String> getUserGroups(Jwt jwt) {
+        return jwt.containsClaim(GROUPS_CLAIM) ? (List<String>) jwt.getClaims().get(GROUPS_CLAIM) : List.of();
     }
 
-    public static boolean containsRole(Jwt jwt, String role){
+    public static boolean containsRole(Jwt jwt, String role) {
         return getUserRoles(jwt).contains(role);
     }
 
-    public static List<String> getUserRoles(Jwt jwt){
-        if(jwt.containsClaim(RESOURCE_ACCESS_CLAIM)){
+    public static List<String> getUserRoles(Jwt jwt) {
+        if (jwt.containsClaim(RESOURCE_ACCESS_CLAIM)) {
             final Map<String, Object> resourceAccess = (Map<String, Object>) jwt.getClaims().get(RESOURCE_ACCESS_CLAIM);
             final Map<String, Object> resource = (Map<String, Object>) resourceAccess.get(API_CLIENT_NAME);
-            if(resource != null)
+            if (resource != null)
                 return (List<String>) resource.get(ROLES_CLAIM);
         }
         return List.of();

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
-keycloak:
+keycloak-moh:
   admin-api-url: https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms/moh_applications
   base-oauth-url: https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications
+keycloak-master:
+  admin-api-url: https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms
+  base-oauth-url: https://common-logon-dev.hlth.gov.bc.ca/auth/realms/master
 user-management-client:
   roles:
     view-clients: view-clients
@@ -31,20 +34,29 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${keycloak.base-oauth-url}
-          jwk-set-uri: ${keycloak.base-oauth-url}/protocol/openid-connect/certs
+          issuer-uri: ${keycloak-moh.base-oauth-url}
+          jwk-set-uri: ${keycloak-moh.base-oauth-url}/protocol/openid-connect/certs
       client:
         registration:
-          keycloak:
+          keycloak-moh:
             client-id: USER-MANAGEMENT-SERVICE
             client-secret: ${UMS_CLIENT_SECRET}
             authorization-grant-type: client_credentials
             scope:
               - openid
+          keycloak-master:
+            client-id: ums-admin
+            client-secret: ${MASTER_UMS_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+            scope:
+              - openid
         provider:
-          keycloak:
-            authorization-url: ${keycloak.base-oauth-url}/protocol/openid-connect/auth
-            token-uri: ${keycloak.base-oauth-url}/protocol/openid-connect/token
+          keycloak-moh:
+            authorization-url: ${keycloak-moh.base-oauth-url}/protocol/openid-connect/auth
+            token-uri: ${keycloak-moh.base-oauth-url}/protocol/openid-connect/token
+          keycloak-master:
+            authorization-url: ${keycloak-master.base-oauth-url}/protocol/openid-connect/auth
+            token-uri: ${keycloak-master.base-oauth-url}/protocol/openid-connect/token
 jasypt:
     encryptor:
         password: ${ums_encryptor_password}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -45,7 +45,7 @@ spring:
             scope:
               - openid
           keycloak-master:
-            client-id: ums-admin
+            client-id: user-management-service-admin
             client-secret: ${MASTER_UMS_CLIENT_SECRET}
             authorization-grant-type: client_credentials
             scope:

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -3,6 +3,7 @@ import { umsRequest } from "./Repository";
 const resource = "/users";
 const clientRoleMappings = "role-mappings/clients";
 const groups ="groups";
+const identityProviderLinks = "federated-identity";
 
 export default {
 
@@ -67,5 +68,9 @@ export default {
         const nameOfGroupToBeDeleted = { data: groupName }
         return umsRequest().then(axiosInstance => axiosInstance.delete(`${resource}/${userId}/${groups}/${groupId}`, nameOfGroupToBeDeleted));
     },
+    resetUserIdentityProviderLink(userId, identityProvider, userIdIdpRealm) {
+        const userIdIdpRealmData = { data: userIdIdpRealm }
+        return umsRequest().then(axiosInstance => axiosInstance.delete(`${resource}/${userId}/${identityProviderLinks}/${identityProvider}`, userIdIdpRealmData));
+    }
 
 }

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -53,7 +53,7 @@
             v-if="totalNumberOfUsersLoadingStatus"
             ref="dashboardSkeleton"
             type="text"
-            max-width="60">
+            max-width="60px">
           </v-skeleton-loader>
         </div>
 

--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -90,10 +90,15 @@
           <label for="linked-idps">Linked Identity Types</label>
           <ul id="linked-idps" style="margin-top: 5px; list-style: square">
             <li v-for="identity in user.federatedIdentities" :key="identity.id">
-              <span style="margin-right: 20px">
+              <span style="margin-right: 4px">
                 {{ identity.identityProvider | formatIdentityProvider }} [{{ identity.userName }}]
               </span>
-              <v-icon @click="openResetIdentityProviderLinkDialog(identity.identityProvider)">mdi-link-variant-off</v-icon>
+              <v-tooltip right>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon small style="vertical-align: middle" @click="openResetIdentityProviderLinkDialog(identity.identityProvider)" v-bind="attrs" v-on="on">mdi-link-variant-off</v-icon>
+                </template>
+                <span>Reset Identity Provider Link</span>
+              </v-tooltip>
             </li>
           </ul>
         </v-col>

--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -217,7 +217,7 @@ export default {
         })
         .catch((error) => {
           this.$store.commit("alert/setAlert", {
-            message: "Error reseting identity provider link: " + error,
+            message: "Error resetting identity provider link: " + error,
             type: "error",
           });
         })

--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -90,12 +90,14 @@
           <label for="linked-idps">Linked Identity Types</label>
           <ul id="linked-idps" style="margin-top: 5px; list-style: square">
             <li v-for="identity in user.federatedIdentities" :key="identity.id">
-              <span style="margin-right: 4px">
+              <span>
                 {{ identity.identityProvider | formatIdentityProvider }} [{{ identity.userName }}]
               </span>
               <v-tooltip right>
                 <template v-slot:activator="{ on, attrs }">
-                  <v-icon small style="vertical-align: middle" @click="openResetIdentityProviderLinkDialog(identity.identityProvider)" v-bind="attrs" v-on="on">mdi-link-variant-off</v-icon>
+                  <v-btn icon v-bind="attrs" v-on="on" @click="openResetIdentityProviderLinkDialog(identity.identityProvider)">
+                    <v-icon small style="vertical-align: middle">mdi-link-variant-off</v-icon>
+                  </v-btn>
                 </template>
                 <span>Reset Identity Provider Link</span>
               </v-tooltip>
@@ -107,19 +109,20 @@
     </v-card>
     <v-dialog v-model="dialog" content-class="resetUserIdentityLinksDialog">
       <v-card>
-               <v-card-title>
-                <span class="headline">Identity Provider Link Reset Confirmation</span>
-              </v-card-title>
-              <v-card-text>
-                Are you sure you want to reset {{ this.selectedIdentityProvider | formatIdentityProvider }} linked identity? Resetting a linked identity will retain existing roles for the user and the identity will be re-linked upon the user's next Keycloak login event.
-              </v-card-text>
-              <v-card-actions>
-                <v-btn class="primary" @click="resetIdentityProviderLink">Reset Identity Provider Link</v-btn>
-                <v-btn outlined class="primary--text" @click="closeResetIdentityProviderLinkDialog">
-                  Cancel
-                </v-btn>
-            </v-card-actions>
-            </v-card>
+        <v-card-title>
+          <span class="headline">Identity Provider Link Reset Confirmation</span>
+        </v-card-title>
+        <v-card-text>
+          <br />
+          Are you sure you want to reset the {{ this.selectedIdentityProvider | formatIdentityProvider }} linked identity for this user?
+          <br /><br />
+          Resetting a linked identity will retain all existing roles and details for the user and the identity will be re-linked upon the user's next Keycloak login event.
+        </v-card-text>
+        <v-card-actions>
+          <v-btn class="primary" @click="resetIdentityProviderLink">Reset Identity Provider Link</v-btn>
+          <v-btn outlined class="primary--text" @click="closeResetIdentityProviderLinkDialog">Cancel</v-btn>
+        </v-card-actions>
+      </v-card>
     </v-dialog>
   </div>
 </template>

--- a/frontend/src/keycloak/index.js
+++ b/frontend/src/keycloak/index.js
@@ -8,7 +8,7 @@ let initOptions = {
     responseMode: 'fragment',
     flow: 'standard',
     onLoad: 'login-required',
-    pkceMethod: 'S256',
+    pkceMethod: 'S256'
 };
 
 // For some reason idpHint cannot be specified in the Keycloak constructor or init options.


### PR DESCRIPTION
Additional config changes required to allow admins to reset the IDP links:

Create client in master realm to allow to delete users from different IDP realms, through UMS.
Client config:

- name: user-management-service-admin
- access type: confidential
- direct access grants: disabled
- service accounts: enabled
- scope mappings: for every idp realm, assign manage-users and view-users roles
- service account roles: for every idp realm, assign manage-users and view-users roles

So far the changes are made on edv environment. They need to be recreated on prod and test.

to test on dev environment: add this entry in application.yaml
`MASTER_UMS_CLIENT_SECRET: ${MASTER_UMS_SECRET}`

this is the client in master realm I've created to delete users from different idp realms.
