### PR TITLE
show users inactive for over a year

### DIFF
--- a/frontend/src/components/UserSearch.vue
+++ b/frontend/src/components/UserSearch.vue
@@ -406,10 +406,8 @@ export default {
           `?briefRepresentation=false&first=0&max=${maxSearch}` + queryParameters
         )).data;
         for (let e of results) {
-          if (e.lastLogDate) {
-            if(e.lastLogDate !== 'Over a year ago'){
-              e.lastLogDate = formatDate(e.lastLogDate);
-            }
+          if (e.lastLogDate && e.lastLogDate !== 'Over a year ago') {
+            e.lastLogDate = formatDate(e.lastLogDate);
           }
         }
         this.setSearchResults(results);

--- a/frontend/src/components/UserSearch.vue
+++ b/frontend/src/components/UserSearch.vue
@@ -407,7 +407,9 @@ export default {
         )).data;
         for (let e of results) {
           if (e.lastLogDate) {
-            e.lastLogDate = formatDate(e.lastLogDate);
+            if(e.lastLogDate !== 'Over a year ago'){
+              e.lastLogDate = formatDate(e.lastLogDate);
+            }
           }
         }
         this.setSearchResults(results);


### PR DESCRIPTION
Adding people who haven't logged in for over a year to results of advanced search in UMC.
I'm adding users who satisfy those requirements:
- have particular roles, but no event entity associated with those roles
- were created over a year ago (so a user who was created recently and haven't logged in yet won't show up in results)

Edge case that is not satisfied:
when an user was created over a year ago, but assigned role recently and haven't logged in yet.
Getting info about every user update would be costly.

That's why I have a question: 
So far for Last Login Date, I'm displaying 'Over a year ago' on Advanced Search Page, and 'N/A' on User Details Page.
I guess it would be good to unify those. Is 'Over a year ago' okay, or maybe 'Inactive' would be more accurate as result may include the edge case as well? 
 
The ` getUsers` function got really long, but there's a task to refactor the whole `UsersController` which I'll do next. Didn't want to mix the changes from feature and refactor. 
