### PR TITLE
Updated max_results

### DIFF
--- a/frontend/env_config/dev/config.json
+++ b/frontend/env_config/dev/config.json
@@ -1,6 +1,6 @@
 {
   "max_search": 100000,
-  "max_results": 100,
+  "max_results": 100000,
   "siteminder_logout": "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi",
   "keycloak_logout": "https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications/protocol/openid-connect/logout",
   "redirect_uri": "https://user-management-dev.hlth.gov.bc.ca",

--- a/frontend/env_config/prod/config.json
+++ b/frontend/env_config/prod/config.json
@@ -1,6 +1,6 @@
 {
   "max_search": 100000,
-  "max_results": 1000,
+  "max_results": 100000,
   "siteminder_logout": "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi",
   "keycloak_logout": "https://common-logon.hlth.gov.bc.ca/auth/realms/moh_applications/protocol/openid-connect/logout",
   "redirect_uri": "https://user-management.hlth.gov.bc.ca",

--- a/frontend/env_config/test/config.json
+++ b/frontend/env_config/test/config.json
@@ -1,6 +1,6 @@
 {
   "max_search": 100000,
-  "max_results": 1000,
+  "max_results": 100000,
   "siteminder_logout": "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi",
   "keycloak_logout": "https://common-logon-test.hlth.gov.bc.ca/auth/realms/moh_applications/protocol/openid-connect/logout",
   "redirect_uri": "https://user-management-test.hlth.gov.bc.ca",


### PR DESCRIPTION
We were planning to go to Prod with `"max_search": 10000, "max_results": 1000` but that would still be an issue for any access teams wanting to audit a full list of users for some apps. Setting a max_results of 10000 is probably the easy fix but maybe not the right fix. For now we can go ahead with this PR as is and maybe we do something like max_search results of 10000 and only respect max_results on specific queries (say for searching without criteria) and for the rest of the queries, just go with a max_results equal to max_search.