### PR TITLE
Add ability to assign MSP Payee number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ target/
 /frontend/nbproject/private/
 frontend/dist/*
 frontend/nbproject/*
+
+yarn.lock

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
@@ -1,10 +1,23 @@
 package ca.bc.gov.hlth.mohums.controller;
 
-import ca.bc.gov.hlth.mohums.exceptions.HttpUnauthorizedException;
-import ca.bc.gov.hlth.mohums.util.AuthorizedClientsParser;
-import ca.bc.gov.hlth.mohums.util.FilterUserByOrgId;
-import ca.bc.gov.hlth.mohums.validator.PermissionsValidator;
-import ca.bc.gov.hlth.mohums.webclient.KeycloakApiService;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -16,20 +29,28 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import ca.bc.gov.hlth.mohums.exceptions.HttpUnauthorizedException;
+import ca.bc.gov.hlth.mohums.model.UserPayee;
+import ca.bc.gov.hlth.mohums.util.AuthorizedClientsParser;
+import ca.bc.gov.hlth.mohums.util.FilterUserByOrgId;
+import ca.bc.gov.hlth.mohums.validator.PermissionsValidator;
+import ca.bc.gov.hlth.mohums.webclient.KeycloakApiService;
+import ca.bc.gov.hlth.mohums.webclient.PayeeApiService;
 
 @RestController
 public class UsersController {
+	
+	private static final String KEY_PAYEE_NUMBER = "payeeNumber";
 
     @Autowired
     private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
@@ -38,11 +59,14 @@ public class UsersController {
     private PermissionsValidator permissionsValidator;
 
     private final KeycloakApiService keycloakApiService;
+    
+    private final PayeeApiService payeeApiService;
 
     private final String vanityHostname;
 
-    public UsersController(KeycloakApiService keycloakApiService, @Value("${config.vanity-hostname}") String vanityHostname) {
+    public UsersController(KeycloakApiService keycloakApiService, PayeeApiService payeeApiService, @Value("${config.vanity-hostname}") String vanityHostname) {
         this.keycloakApiService = keycloakApiService;
+        this.payeeApiService = payeeApiService;
         this.vanityHostname = vanityHostname;
     }
 
@@ -368,6 +392,34 @@ public class UsersController {
     @DeleteMapping("/users/{userId}/federated-identity/{identityProvider}")
     public ResponseEntity<Object> removeUserIdentityProviderLinks(@PathVariable String userId, @PathVariable String identityProvider, @RequestBody String userIdIdpRealm){
         return keycloakApiService.removeUserIdentityProviderLink(userId, identityProvider, userIdIdpRealm);
+    }
+    
+    @GetMapping("/users/{userId}/payee")
+    public ResponseEntity<Object> getUserPayee(@PathVariable String userId) {
+		return payeeApiService.getPayee(userId);
+    }
+    
+    @SuppressWarnings("unchecked")
+	@PutMapping("/users/{userId}/payee")
+    public ResponseEntity<String> updateUserPayee(@PathVariable String userId, @RequestBody String payee) {
+    	// Check the existing payee
+    	String existingPayee = ((LinkedHashMap<String, String>)payeeApiService.getPayee(userId).getBody()).get(KEY_PAYEE_NUMBER);
+    	if (StringUtils.isEmpty(existingPayee)) {
+    		if (StringUtils.isNotEmpty(payee)) {
+    			// Add a new record
+    		} else {
+    			// No change - do nothing
+    			return ResponseEntity.ok(payee);
+    		}
+    	} else {
+    		if (StringUtils.isNotEmpty(payee)) {
+    			// Update the existing record
+    		} else {
+    			// Delete the existing record
+    		}
+    	}
+    	
+    	return ResponseEntity.ok(payee);
     }
 
     private static final Pattern patternGuid = Pattern.compile(".*/users/(.{8}-.{4}-.{4}-.{4}-.{12})");

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
@@ -50,7 +50,7 @@ import ca.bc.gov.hlth.mohums.webclient.PayeeApiService;
 @RestController
 public class UsersController {
 	
-	private static final String KEY_PAYEE_NUMBER = "payeeNumber";
+    private static final String KEY_PAYEE_NUMBER = "payeeNumber";
 
     @Autowired
     private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
@@ -396,47 +396,48 @@ public class UsersController {
     
     @GetMapping("/users/{userId}/payee")
     public ResponseEntity<Object> getUserPayee(@PathVariable String userId) {
-		ResponseEntity<Object> response = payeeApiService.getPayee(userId);
-		// A 404 is a legitimate response if the user doesn't have a Payee defined
-		// Convert it and return an empty response instead.
-		if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
-			return ResponseEntity.ok(null);
-		}
-		return response;
+        ResponseEntity<Object> response = payeeApiService.getPayee(userId);
+        // A 404 is a legitimate response if the user doesn't have a Payee defined
+        // Convert it and return an empty response instead.
+        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+            return ResponseEntity.ok(null);
+        }
+        return response;
     }
     
     @SuppressWarnings("unchecked")
-	@PutMapping("/users/{userId}/payee")
+    @PutMapping("/users/{userId}/payee")
     public ResponseEntity<Object> updateUserPayee(@PathVariable String userId, @RequestBody(required = false) String payee) {
-    	// Check the existing payee
-    	String existingPayee = ((LinkedHashMap<String, String>)payeeApiService.getPayee(userId).getBody()).get(KEY_PAYEE_NUMBER);
+        // Get the existing payee
+        String existingPayee = ((LinkedHashMap<String, String>) payeeApiService.getPayee(userId).getBody()).get(KEY_PAYEE_NUMBER);
 
-		// No change - do nothing    	
-    	if (StringUtils.equals(payee, existingPayee)) {
-    		return ResponseEntity.ok(payee);		
-    	}
-    	if (StringUtils.isEmpty(existingPayee)) {
-    		if (StringUtils.isNotEmpty(payee)) {
-    			// Add a new record
-    			UserPayee userPayee = new UserPayee();    			
-    			userPayee.setPayeeNumber(payee);
-    			userPayee.setUserGuid(userId);
-    			return payeeApiService.addPayee(userPayee);
-    		} else {
-    			return ResponseEntity.ok(payee);
-    		}
-    	} else {
-    		if (StringUtils.isNotEmpty(payee)) {
-    			// Update the existing record
-    			UserPayee userPayee = new UserPayee();    			
-    			userPayee.setPayeeNumber(payee);
-    			userPayee.setUserGuid(userId);
-    			return payeeApiService.updatePayee(userId, userPayee);
-    		} else {
-    			// Delete the existing record
-    			return payeeApiService.deletePayee(userId);
-    		}
-    	}
+        // No change - do nothing
+        if (StringUtils.equals(payee, existingPayee)) {
+            return ResponseEntity.ok(payee);
+        }
+        if (StringUtils.isEmpty(existingPayee)) {
+            if (StringUtils.isNotEmpty(payee)) {
+                // Add a new record
+                UserPayee userPayee = new UserPayee();
+                userPayee.setPayeeNumber(payee);
+                userPayee.setUserGuid(userId);
+                return payeeApiService.addPayee(userPayee);
+            } else {
+                // Technically this won't happen as this would be "no change"
+                return ResponseEntity.ok(payee);
+            }
+        } else {
+            if (StringUtils.isNotEmpty(payee)) {
+                // Update the existing record
+                UserPayee userPayee = new UserPayee();
+                userPayee.setPayeeNumber(payee);
+                userPayee.setUserGuid(userId);
+                return payeeApiService.updatePayee(userId, userPayee);
+            } else {
+                // Delete the existing record
+                return payeeApiService.deletePayee(userId);
+            }
+        }
     }
 
     private static final Pattern patternGuid = Pattern.compile(".*/users/(.{8}-.{4}-.{4}-.{4}-.{12})");

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/model/UserPayee.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/model/UserPayee.java
@@ -1,0 +1,24 @@
+package ca.bc.gov.hlth.mohums.model;
+
+public class UserPayee {
+	private String userGuid;
+
+	private String payeeNumber;
+
+	public String getUserGuid() {
+		return userGuid;
+	}
+
+	public void setUserGuid(String userGuid) {
+		this.userGuid = userGuid;
+	}
+
+	public String getPayeeNumber() {
+		return payeeNumber;
+	}
+
+	public void setPayeeNumber(String payeeNumber) {
+		this.payeeNumber = payeeNumber;
+	}
+
+}

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/model/UserPayee.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/model/UserPayee.java
@@ -1,24 +1,24 @@
 package ca.bc.gov.hlth.mohums.model;
 
 public class UserPayee {
-	private String userGuid;
+    private String userGuid;
 
-	private String payeeNumber;
+    private String payeeNumber;
 
-	public String getUserGuid() {
-		return userGuid;
-	}
+    public String getUserGuid() {
+        return userGuid;
+    }
 
-	public void setUserGuid(String userGuid) {
-		this.userGuid = userGuid;
-	}
+    public void setUserGuid(String userGuid) {
+        this.userGuid = userGuid;
+    }
 
-	public String getPayeeNumber() {
-		return payeeNumber;
-	}
+    public String getPayeeNumber() {
+        return payeeNumber;
+    }
 
-	public void setPayeeNumber(String payeeNumber) {
-		this.payeeNumber = payeeNumber;
-	}
+    public void setPayeeNumber(String payeeNumber) {
+        this.payeeNumber = payeeNumber;
+    }
 
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/security/SecurityConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/security/SecurityConfig.java
@@ -87,6 +87,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .mvcMatchers(HttpMethod.PUT,"/users/{userId}/groups/{groupId}").hasAnyRole(manageOwnGroupsRole, manageAllGroupsRole)
                 .mvcMatchers(HttpMethod.DELETE,"/users/{userId}/groups/{groupId}").hasAnyRole(manageOwnGroupsRole, manageAllGroupsRole)
                 .mvcMatchers(HttpMethod.DELETE, "/users/{userId}/role-mappings/**").hasRole(manageUserRolesRole)
+                .mvcMatchers(HttpMethod.PUT, "/users/{userId}/payee/**").hasRole(manageUserRolesRole)
                 .mvcMatchers("/*").denyAll()
                 .and()
             .oauth2ResourceServer().jwt()

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/ExternalApiCallerConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/ExternalApiCallerConfig.java
@@ -22,4 +22,9 @@ public class ExternalApiCallerConfig {
     public ExternalApiCaller keycloakMasterApiCaller(@Qualifier("kcMasterAuthorizedWebClient") WebClient keycloakMasterWebClient){
         return new ExternalApiCaller(keycloakMasterWebClient);
     }
+    
+    @Bean("payeeApiCaller")
+    public ExternalApiCaller payeeApiCaller(@Qualifier("payeeApiAuthorizedWebClient") WebClient payeeApiAuthorizedWebClient){
+        return new ExternalApiCaller(payeeApiAuthorizedWebClient);
+    }
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/PayeeApiService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/PayeeApiService.java
@@ -4,10 +4,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import ca.bc.gov.hlth.mohums.model.UserPayee;
+
 @Service
 public class PayeeApiService {
 
-    private final String payeePath = "/payee-mapping";
+    private static final String PAYEE_PATH = "/payee-mapping";
 
     private final ExternalApiCaller payeeApiCaller;
 
@@ -16,9 +18,27 @@ public class PayeeApiService {
     }
     
     public ResponseEntity<Object> getPayee(String userId) {
-    	String path = String.format("%s/%s", payeePath, userId);
+    	String path = String.format("%s/%s", PAYEE_PATH, userId);
     	
     	return payeeApiCaller.get(path, null);
+    }
+    
+    public ResponseEntity<Object> addPayee(UserPayee payee) {
+    	String path = String.format("%s", PAYEE_PATH);
+    	
+    	return payeeApiCaller.post(path, payee);
+    }
+    
+    public ResponseEntity<Object> updatePayee(String userId, UserPayee payee) {
+    	String path = String.format("%s/%s", PAYEE_PATH, userId);
+    	
+    	return payeeApiCaller.put(path, payee);
+    }
+    
+    public ResponseEntity<Object> deletePayee(String userId) {
+    	String path = String.format("%s/%s", PAYEE_PATH, userId);
+    	
+    	return payeeApiCaller.delete(path);
     }
 
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/PayeeApiService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/PayeeApiService.java
@@ -1,0 +1,24 @@
+package ca.bc.gov.hlth.mohums.webclient;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PayeeApiService {
+
+    private final String payeePath = "/payee-mapping";
+
+    private final ExternalApiCaller payeeApiCaller;
+
+    public PayeeApiService(@Qualifier("payeeApiCaller") ExternalApiCaller payeeApiCaller) {
+        this.payeeApiCaller = payeeApiCaller;
+    }
+    
+    public ResponseEntity<Object> getPayee(String userId) {
+    	String path = String.format("%s/%s", payeePath, userId);
+    	
+    	return payeeApiCaller.get(path, null);
+    }
+
+}

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
@@ -97,7 +97,6 @@ public class WebClientConfig {
     
     @Bean("payeeApiAuthorizedWebClient")
     public WebClient payeeWebClient(OAuth2AuthorizedClientManager authorizedClientManager) {
-
         String registrationId = "keycloak-moh";
         ServletOAuth2AuthorizedClientExchangeFilterFunction oauth = createOauthFilterFunction(authorizedClientManager, registrationId);
         return createWebClient(oauth, mspDirectApiBaseUrl);

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/WebClientConfig.java
@@ -33,6 +33,9 @@ public class WebClientConfig {
 
     @Value("${keycloak-moh.organizations-api-url}")
     private String organizationsApiBaseUrl;
+    
+    @Value("${keycloak-moh.mspdirect-api-url}")
+    private String mspDirectApiBaseUrl;
 
     @Value("${spring.codec.max-in-memory-size-mb}")
     int maxInMemorySize;
@@ -90,6 +93,14 @@ public class WebClientConfig {
         } else {
             return createWebClientWithProxy(oauth, organizationsApiBaseUrl);
         }
+    }
+    
+    @Bean("payeeApiAuthorizedWebClient")
+    public WebClient payeeWebClient(OAuth2AuthorizedClientManager authorizedClientManager) {
+
+        String registrationId = "keycloak-moh";
+        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth = createOauthFilterFunction(authorizedClientManager, registrationId);
+        return createWebClient(oauth, mspDirectApiBaseUrl);
     }
 
     private ServletOAuth2AuthorizedClientExchangeFilterFunction createOauthFilterFunction(OAuth2AuthorizedClientManager authorizedClientManager, String registrationId) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ keycloak-moh:
   admin-api-url: https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms/moh_applications
   base-oauth-url: https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications
   organizations-api-url: https://organizations-api.cey5wq-dev.nimbus.cloud.gov.bc.ca
-  mspdirect-api-url: http://localhost:9091
+  mspdirect-api-url: https://mspdirect-dev-api.apps.silver.devops.gov.bc.ca
 keycloak-master:
   admin-api-url: https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms
   base-oauth-url: https://common-logon-dev.hlth.gov.bc.ca/auth/realms/master

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -2,6 +2,7 @@ keycloak-moh:
   admin-api-url: https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms/moh_applications
   base-oauth-url: https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications
   organizations-api-url: https://organizations-api.cey5wq-dev.nimbus.cloud.gov.bc.ca
+  mspdirect-api-url: http://localhost:9091
 keycloak-master:
   admin-api-url: https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms
   base-oauth-url: https://common-logon-dev.hlth.gov.bc.ca/auth/realms/master

--- a/backend/src/test/java/ca/bc/gov/hlth/mohums/controller/UsersControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/mohums/controller/UsersControllerTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class UsersControllerTest {
 
-    private final UsersController u = new UsersController(null, vanityHostname);
+    private final UsersController u = new UsersController(null, null, vanityHostname);
 
     private static final String vanityHostname = "http://localhost";
 

--- a/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MspDirectApiIntegrationTests.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MspDirectApiIntegrationTests.java
@@ -1,0 +1,261 @@
+package ca.bc.gov.hlth.mohums.integration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import ca.bc.gov.hlth.mohums.model.UserPayee;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MspDirectApiIntegrationTests {
+
+    private static final JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+    
+    private static final String PAYEE_PATH = "/payee-mapping";
+
+    @Value("${spring.security.oauth2.client.provider.keycloak-moh.token-uri}")
+    private String keycloakTokenUri;
+
+    @Value("${spring.security.oauth2.client.registration.keycloak-moh.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.keycloak-moh.client-secret}")
+    private String clientSecret;
+
+    @Value("${keycloak-moh.mspdirect-api-url}")
+    private String mspDirectApiBaseUrl;
+
+    @Autowired
+    private WebTestClient payeeApiWebTestClient;
+
+    private String jwt;
+
+    /** This is mspdirect_payee_test in Dev. This technically doesn't require a real account
+     *  since MSP Direct doesn't validate the id. So tests will continue to function if the user
+     *  is removed.*/
+    private String testClientId = "2ee882b4-53b0-408a-8ed7-fef2a15a98d0";
+    
+    private String nonexistentClientId = "1b6c8a7e-f1e1-4ad5-be99-fd62c45ba482";
+
+    @BeforeAll
+    public void getJWT() throws InterruptedException, ParseException, IOException {
+        jwt = getKcAccessToken();
+
+        payeeApiWebTestClient = payeeApiWebTestClient
+                .mutate()
+                .baseUrl(mspDirectApiBaseUrl)
+                .responseTimeout(Duration.ofSeconds(120))
+                .build();
+    }
+    
+    @BeforeEach
+    public void resetPayee() {
+    	deleteTestPayee();
+        addTestPayee();
+    }
+
+    @AfterAll
+    public void cleanupPayee() {
+        deleteTestPayee();
+    }
+
+    private String getKcAccessToken() throws IOException, InterruptedException, ParseException {
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(keycloakTokenUri))
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("cache-control", "no-cache")
+                .POST(HttpRequest.BodyPublishers.ofString("grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        JSONObject responseBodyAsJson = (JSONObject) jsonParser.parse(response.body());
+        String access_token = responseBodyAsJson.get("access_token").toString();
+
+        return access_token;
+    }
+
+    @Test
+    public void testGetPayee_success() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+
+        UserPayee userPayee = payeeApiWebTestClient
+                .get()
+                .uri(String.format("%s/%s", PAYEE_PATH, testClientId))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(UserPayee.class)
+                .returnResult()
+                .getResponseBody();
+
+        Assertions.assertThat(userPayee).isNotNull();
+        Assertions.assertThat(userPayee.getPayeeNumber()).isEqualTo("ABC123");
+        Assertions.assertThat(userPayee.getUserGuid()).isEqualTo(testClientId);
+    }
+    
+    @Test
+    public void testGetPayee_notFound() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+
+        payeeApiWebTestClient
+                .get()
+                .uri(String.format("%s/%s", PAYEE_PATH, nonexistentClientId))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+    
+    @Test
+    public void testDeletePayee_success() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+
+        payeeApiWebTestClient
+                .delete()
+                .uri(String.format("%s/%s", PAYEE_PATH,  testClientId))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isNoContent();       	
+    }
+    
+    @Test
+    public void testDeletePayee_notFound() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+
+        payeeApiWebTestClient
+                .delete()
+                .uri(String.format("%s/%s", PAYEE_PATH,  nonexistentClientId))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+    
+    @Test
+    public void testAddPayee_success() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+  
+    	deleteTestPayee();
+
+    	UserPayee userPayee = payeeApiWebTestClient
+                .post()
+                .uri(PAYEE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createUserPayee(testClientId, "ABC123"))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(UserPayee.class)
+                .returnResult()
+                .getResponseBody();
+        
+        Assertions.assertThat(userPayee).isNotNull();
+        Assertions.assertThat(userPayee.getPayeeNumber()).isEqualTo("ABC123");
+        Assertions.assertThat(userPayee.getUserGuid()).isEqualTo(testClientId);
+    }
+    
+    @Test
+    public void testAddPayee_conflict() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+    	
+        payeeApiWebTestClient
+                .post()
+                .uri(PAYEE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createUserPayee(testClientId, "ABC123"))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.CONFLICT);
+    }
+    
+    @Test
+    public void testUpdatePayee_success() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+
+    	UserPayee userPayee = payeeApiWebTestClient
+                .put()
+                .uri(String.format("%s/%s", PAYEE_PATH,  testClientId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createUserPayee(testClientId, "DEF456"))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(UserPayee.class)
+                .returnResult()
+                .getResponseBody();
+    	
+        Assertions.assertThat(userPayee).isNotNull();
+        Assertions.assertThat(userPayee.getPayeeNumber()).isEqualTo("DEF456");
+        Assertions.assertThat(userPayee.getUserGuid()).isEqualTo(testClientId);
+    }
+    
+    @Test
+    public void testUpdatePayee_notFound() {
+    	Assumptions.assumeTrue(isDevEnvironment());
+
+    	payeeApiWebTestClient
+                .put()
+                .uri(String.format("%s/%s", PAYEE_PATH,  nonexistentClientId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createUserPayee(nonexistentClientId, "DEF456"))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+    private void addTestPayee() {
+    	payeeApiWebTestClient
+                .post()
+                .uri(PAYEE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createUserPayee(testClientId, "ABC123"))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange();
+    }
+
+    private void deleteTestPayee() {
+        payeeApiWebTestClient
+                .delete()
+                .uri(String.format("%s/%s", PAYEE_PATH, testClientId))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange();
+    }
+    
+    private UserPayee createUserPayee(String userGuid, String payeeNumber) {
+    	UserPayee userPayee = new UserPayee();
+    	userPayee.setPayeeNumber(payeeNumber);
+    	userPayee.setUserGuid(userGuid);
+    	return userPayee;
+    }
+
+    private boolean isDevEnvironment() {
+        return mspDirectApiBaseUrl.contains("dev");
+    }
+}

--- a/frontend/env_config/dev/config.json
+++ b/frontend/env_config/dev/config.json
@@ -6,5 +6,6 @@
   "redirect_uri": "https://user-management-dev.hlth.gov.bc.ca",
   "service_url": "https://user-management-dev.api.hlth.gov.bc.ca",
   "sfds_url": "https://sfdsdev.hlth.gov.bc.ca/sfds-api",
-  "app_title": "MoH User Management (Dev)"
+  "app_title": "MoH User Management (Dev)",
+  "mspdirect_clients": ["MSPDIRECT-SERVICE"]
 }

--- a/frontend/env_config/dev/config.json
+++ b/frontend/env_config/dev/config.json
@@ -7,5 +7,5 @@
   "service_url": "https://user-management-dev.api.hlth.gov.bc.ca",
   "sfds_url": "https://sfdsdev.hlth.gov.bc.ca/sfds-api",
   "app_title": "MoH User Management (Dev)",
-  "mspdirect_clients": ["MSPDIRECT-SERVICE"]
+  "mspdirect_client": "MSPDIRECT-SERVICE"
 }

--- a/frontend/env_config/prod/config.json
+++ b/frontend/env_config/prod/config.json
@@ -6,5 +6,6 @@
   "redirect_uri": "https://user-management.hlth.gov.bc.ca",
   "service_url": "https://user-management.api.hlth.gov.bc.ca",
   "sfds_url": "https://sfds.hlth.gov.bc.ca/sfds-api",
-  "app_title": "MoH User Management"
+  "app_title": "MoH User Management",
+  "mspdirect_client": "MSPDIRECT-SERVICE"
 }

--- a/frontend/env_config/test/config.json
+++ b/frontend/env_config/test/config.json
@@ -6,5 +6,6 @@
   "redirect_uri": "https://user-management-test.hlth.gov.bc.ca",
   "service_url": "https://user-management-test.api.hlth.gov.bc.ca",
   "sfds_url": "https://sfdstst.hlth.gov.bc.ca/sfds-api",
-  "app_title": "MoH User Management (Test)"
+  "app_title": "MoH User Management (Test)",
+  "mspdirect_client": "MSPDIRECT-SERVICE"
 }

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -7,5 +7,5 @@
   "service_url": "http://localhost:9090",
   "sfds_url": "https://sfdsdev.hlth.gov.bc.ca/sfds-api",
   "app_title": "MoH User Management (Dev)",
-  "mspdirect_clients": ["MSPDIRECT-SERVICE"]
+  "mspdirect_client": "MSPDIRECT-SERVICE"
 }

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -6,5 +6,6 @@
   "redirect_uri": "http://localhost:8080",
   "service_url": "http://localhost:9090",
   "sfds_url": "https://sfdsdev.hlth.gov.bc.ca/sfds-api",
-  "app_title": "MoH User Management (Dev)"
+  "app_title": "MoH User Management (Dev)",
+  "mspdirect_clients": ["MSPDIRECT-SERVICE"]
 }

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -123,4 +123,17 @@ export default {
       )
     );
   },
+  /** User Payee */
+  getUserPayee(userId) {
+    return umsRequest().then((axiosInstance) =>
+      axiosInstance.get(`${resource}/${userId}/payee`)
+    );
+  },
+  updateUserPayee(userId, payee) {
+    return umsRequest().then((axiosInstance) =>
+      axiosInstance.put(`${resource}/${userId}/payee`, payee, {
+        headers: { "Content-Type": "text/plain" },
+      })
+    );
+  },
 };

--- a/frontend/src/components/UserPayee.vue
+++ b/frontend/src/components/UserPayee.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card>
+  <v-card class="payee-card">
     <v-card-title>
       <span class="headline">Edit User Payee</span>
     </v-card-title>
@@ -11,7 +11,7 @@
         outlined
         id="payee"
         maxlength="10"
-        v-model="payee"
+        v-model.trim="payee"
       />
     </v-card-text>
 
@@ -23,25 +23,18 @@
 </template>
 
 <script>
-  import UsersRepository from "@/api/UsersRepository";
-
   export default {
     name: "UserPayee",
     components: {},
     props: {
-      userId: {
+      initialPayee: {
         type: String,
         required: false,
       },
     },
-    async created() {
-      console.log("created");
-      let response = await UsersRepository.getUserPayee(this.userId);
-      this.payee = response.data.payeeNumber;
-    },
     data() {
       return {
-        payee: "",
+        payee: this.initialPayee,
       };
     },
     methods: {
@@ -56,6 +49,9 @@
 </script>
 
 <style scoped>
+  .payee-card {
+    padding: 15px;
+  }
   .payee-text-field {
     width: 200px;
   }

--- a/frontend/src/components/UserPayee.vue
+++ b/frontend/src/components/UserPayee.vue
@@ -1,0 +1,62 @@
+<template>
+  <v-card>
+    <v-card-title>
+      <span class="headline">Edit User Payee</span>
+    </v-card-title>
+    <v-card-text>
+      <label dense for="payee">Payee</label>
+      <v-text-field
+        class="payee-text-field"
+        dense
+        outlined
+        id="payee"
+        maxlength="10"
+        v-model="payee"
+      />
+    </v-card-text>
+
+    <v-card-actions>
+      <v-btn class="primary" @click="save()">Save Payee</v-btn>
+      <v-btn outlined class="primary--text" @click="close()">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+  import UsersRepository from "@/api/UsersRepository";
+
+  export default {
+    name: "UserPayee",
+    components: {},
+    props: {
+      userId: {
+        type: String,
+        required: false,
+      },
+    },
+    async created() {
+      console.log("created");
+      let response = await UsersRepository.getUserPayee(this.userId);
+      this.payee = response.data.payeeNumber;
+    },
+    data() {
+      return {
+        payee: "",
+      };
+    },
+    methods: {
+      close() {
+        this.$emit("close");
+      },
+      save() {
+        this.$emit("save", this.payee);
+      },
+    },
+  };
+</script>
+
+<style scoped>
+  .payee-text-field {
+    width: 200px;
+  }
+</style>

--- a/frontend/src/components/UserUpdateRoles.vue
+++ b/frontend/src/components/UserUpdateRoles.vue
@@ -187,12 +187,12 @@
                   Cancel
                 </v-btn>
               </v-card-actions>
-              <div v-if="showUserPayee">
+              <div v-if="showUserPayee && !isClientRoleLoading">
                 <v-divider />
                 <user-payee
                   @close="close()"
                   @save="updateUserPayee"
-                  :userId="userId"
+                  :initialPayee="payee"
                 />
               </div>
             </v-card>
@@ -258,6 +258,7 @@
         isEdit: false,
         isClientRoleLoading: false,
         LAST_LOGIN_NOT_RECORDED,
+        payee: "",
       };
     },
     async created() {
@@ -289,9 +290,7 @@
         ].roles.includes(manageUserRolesName);
       },
       showUserPayee() {
-        return this.$config.mspdirect_clients.includes(
-          this.selectedClient?.clientId
-        );
+        return this.selectedClient?.clientId === this.$config.mspdirect_client;
       },
     },
     methods: {
@@ -383,6 +382,11 @@
         this.clientRoles.push(...clientRolesResponses[2].data);
         this.selectedRoles.push(...clientRolesResponses[2].data);
         this.effectiveClientRoles.push(...clientRolesResponses[0].data);
+
+        if (this.showUserPayee) {
+          const response = await UsersRepository.getUserPayee(this.userId);
+          this.payee = response.data.payeeNumber;
+        }
 
         this.isClientRoleLoading = false;
 

--- a/frontend/src/components/UserUpdateRoles.vue
+++ b/frontend/src/components/UserUpdateRoles.vue
@@ -190,7 +190,7 @@
               <div v-if="showUserPayee && !isClientRoleLoading">
                 <v-divider />
                 <user-payee
-                  @close="close()"
+                  @close="close"
                   @save="updateUserPayee"
                   :initialPayee="payee"
                 />

--- a/frontend/src/components/UserUpdateRoles.vue
+++ b/frontend/src/components/UserUpdateRoles.vue
@@ -187,6 +187,14 @@
                   Cancel
                 </v-btn>
               </v-card-actions>
+              <div v-if="showUserPayee">
+                <v-divider />
+                <user-payee
+                  @close="close()"
+                  @save="updateUserPayee"
+                  :userId="userId"
+                />
+              </div>
             </v-card>
           </v-dialog>
         </v-toolbar>
@@ -224,10 +232,12 @@
 <script>
   import ClientsRepository from "@/api/ClientsRepository";
   import UsersRepository from "@/api/UsersRepository";
+  import UserPayee from "@/components/UserPayee.vue";
 
   const LAST_LOGIN_NOT_RECORDED = -1;
   export default {
     name: "UserUpdateRoles",
+    components: { UserPayee },
     props: ["userId"],
     data() {
       return {
@@ -277,6 +287,11 @@
         return !!this.$keycloak.tokenParsed.resource_access[
           umsClientId
         ].roles.includes(manageUserRolesName);
+      },
+      showUserPayee() {
+        return this.$config.mspdirect_clients.includes(
+          this.selectedClient?.clientId
+        );
       },
     },
     methods: {
@@ -439,6 +454,25 @@
           })
           .finally(() => {
             this.$root.$refs.UserMailboxAuthorizations.getMailboxClients();
+            window.scrollTo(0, 0);
+          });
+      },
+      updateUserPayee: function (payee) {
+        UsersRepository.updateUserPayee(this.userId, payee)
+          .then(() => {
+            this.$store.commit("alert/setAlert", {
+              message: "Payee updated successfully",
+              type: "success",
+            });
+            this.close();
+          })
+          .catch((error) => {
+            this.$store.commit("alert/setAlert", {
+              message: "Error updating payee: " + error,
+              type: "error",
+            });
+          })
+          .finally(() => {
             window.scrollTo(0, 0);
           });
       },


### PR DESCRIPTION
See https://dev.azure.com/cgi-vic-hlth/AM%20Team/_workitems/edit/7203.

UMC
- Added new component and integrated with existing User Roles popup
- Added Service method
- Added configuration

UMS
- Added new endpoint. For simplicity a single PUT endpoint was defined for adding/updating/removing the value. UMS will determine which MSP Direct endpoint to call.
- Added code for calling MSP Direct.
- Added integration test for MSP Direct Payee Mapping API