### PR TITLE
Ab#9969 restrict access to service accounts through umc

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/KeycloakApiService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/KeycloakApiService.java
@@ -82,14 +82,13 @@ public class KeycloakApiService {
         } else {
             response = searchResults;
         }
-
         return response;
     }
 
     private List<Object> filterOutServiceAccounts(List<Object> searchResults) {
         return searchResults.stream()
                 .map(user -> (LinkedHashMap) user)
-                .filter(user -> !user.get("username").toString().contains("service-account-"))
+                .filter(user -> !isServiceAccount(user))
                 .collect(Collectors.toList());
     }
 
@@ -99,12 +98,16 @@ public class KeycloakApiService {
 
         if (userResponse.getStatusCode().is2xxSuccessful()) {
             LinkedHashMap user = (LinkedHashMap) userResponse.getBody();
-            if (user.get("username").toString().contains("service-account-")) {
+            if (isServiceAccount(user)) {
                 userResponse = ResponseEntity.status(HttpStatus.FORBIDDEN).body("Service account cannot be accessed through UMC");
             }
         }
 
         return userResponse;
+    }
+
+    private boolean isServiceAccount(LinkedHashMap userAttributes){
+        return userAttributes.get("username").toString().contains("service-account-");
     }
 
     public ResponseEntity<Object> createUser(Object data) {

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/KeycloakApiService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/KeycloakApiService.java
@@ -17,14 +17,14 @@ import java.util.stream.Collectors;
 @Service
 public class KeycloakApiService {
 
-    private final String clientsPath = "/clients";
-    private final String usersPath = "/users";
-    private final String groupsPath = "/groups";
-    private final String identityProviderLinksPath = "/federated-identity";
-    private final String userClientRoleMappingPath = "/role-mappings/clients/";
-    private final String serviceAccountPrefix = "service-account-";
-    private final String usernameAttribute = "username";
-    private final String serviceAccountForbiddenMessage = "Service account cannot be accessed through UMC";
+    private static final String CLIENTS_PATH = "/clients";
+    private static final String USERS_PATH = "/users";
+    private static final String GROUPS_PATH = "/groups";
+    private static final String IDENTITY_PROVIDER_LINKS_PATH = "/federated-identity";
+    private static final String USER_CLIENT_ROLE_MAPPING_PATH = "/role-mappings/clients/";
+    private static final String SERVICE_ACCOUNT_PREFIX = "service-account-";
+    private static final String USERNAME_ATTRIBUTE = "username";
+    private static final String SERVICE_ACCOUNT_FORBIDDEN_MESSAGE = "Service account cannot be accessed through UMC";
     private final ExternalApiCaller keycloakMohExternalApiCaller;
     private final ExternalApiCaller keycloakMasterExternalApiCaller;
 
@@ -35,30 +35,30 @@ public class KeycloakApiService {
 
     // Clients
     public ResponseEntity<List<Object>> getClients() {
-        return keycloakMohExternalApiCaller.getList(clientsPath);
+        return keycloakMohExternalApiCaller.getList(CLIENTS_PATH);
 
     }
 
     public ResponseEntity<Object> getClient(String clientId) {
-        String path = clientsPath + "/" + clientId;
+        String path = CLIENTS_PATH + "/" + clientId;
         return keycloakMohExternalApiCaller.get(path, null);
     }
 
     public ResponseEntity<List<Object>> getClientRoles(String clientId) {
-        String path = String.format("%s/%s/roles", clientsPath, clientId);
+        String path = String.format("%s/%s/roles", CLIENTS_PATH, clientId);
         return keycloakMohExternalApiCaller.getList(path, null);
     }
 
     public ResponseEntity<List<Object>> getUsersInRole(String clientId, String roleName,
                                                        MultiValueMap<String, String> queryParams) {
-        String path = String.format("%s/%s/roles/%s/users", clientsPath, clientId, roleName);
+        String path = String.format("%s/%s/roles/%s/users", CLIENTS_PATH, clientId, roleName);
         return keycloakMohExternalApiCaller.getList(path, queryParams);
     }
 
     // Groups
     @SuppressWarnings("unchecked")
     public ResponseEntity<Object> getGroups() {
-        ResponseEntity<Object> response = keycloakMohExternalApiCaller.get(groupsPath, null);
+        ResponseEntity<Object> response = keycloakMohExternalApiCaller.get(GROUPS_PATH, null);
         ArrayList<LinkedHashMap<String, Object>> groups = (ArrayList<LinkedHashMap<String, Object>>) response.getBody();
         List<Group> groupList = groups.stream().map(g -> getGroupById(g.get("id").toString())).collect(Collectors.toList());
         return ResponseEntity.of(Optional.of(groupList));
@@ -67,14 +67,14 @@ public class KeycloakApiService {
     // Group details
     @SuppressWarnings("unchecked")
     private Group getGroupById(String groupId) {
-        String path = String.format("%s/%s", groupsPath, groupId);
+        String path = String.format("%s/%s", GROUPS_PATH, groupId);
         ResponseEntity<Object> response = keycloakMohExternalApiCaller.get(path, null);
         return GroupDescriptionGenerator.createGroupWithDescription((LinkedHashMap<String, Object>) response.getBody());
     }
 
     // Users
     public ResponseEntity<List<Object>> getUsers(MultiValueMap<String, String> queryParams) {
-        ResponseEntity<List<Object>> searchResults = keycloakMohExternalApiCaller.getList(usersPath, queryParams);
+        ResponseEntity<List<Object>> searchResults = keycloakMohExternalApiCaller.getList(USERS_PATH, queryParams);
         ResponseEntity<List<Object>> response;
 
         if (searchResults.getStatusCode().is2xxSuccessful()) {
@@ -98,13 +98,13 @@ public class KeycloakApiService {
     }
     @SuppressWarnings("unchecked")
     public ResponseEntity<Object> getUser(String userId) {
-        String path = usersPath + "/" + userId;
+        String path = USERS_PATH + "/" + userId;
         ResponseEntity<Object> userResponse = keycloakMohExternalApiCaller.get(path, null);
 
         if (userResponse.getStatusCode().is2xxSuccessful()) {
             LinkedHashMap<String, Object> user = (LinkedHashMap<String, Object>) userResponse.getBody();
             if (isServiceAccount(user)) {
-                userResponse = ResponseEntity.status(HttpStatus.FORBIDDEN).body(serviceAccountForbiddenMessage);
+                userResponse = ResponseEntity.status(HttpStatus.FORBIDDEN).body(SERVICE_ACCOUNT_FORBIDDEN_MESSAGE);
             }
         }
 
@@ -112,55 +112,55 @@ public class KeycloakApiService {
     }
 
     private boolean isServiceAccount(LinkedHashMap<String, Object> userAttributes){
-        return userAttributes.get(usernameAttribute).toString().startsWith(serviceAccountPrefix);
+        return userAttributes.get(USERNAME_ATTRIBUTE).toString().startsWith(SERVICE_ACCOUNT_PREFIX);
     }
 
     public ResponseEntity<Object> createUser(Object data) {
-        return keycloakMohExternalApiCaller.post(usersPath, data);
+        return keycloakMohExternalApiCaller.post(USERS_PATH, data);
     }
 
     public ResponseEntity<Object> updateUser(String userId, Object data) {
-        String path = usersPath + "/" + userId;
+        String path = USERS_PATH + "/" + userId;
         return keycloakMohExternalApiCaller.put(path, data);
     }
 
     public ResponseEntity<Object> getAssignedUserClientRoleMappings(String userId, String clientId) {
-        String path = usersPath + "/" + userId + userClientRoleMappingPath + clientId;
+        String path = USERS_PATH + "/" + userId + USER_CLIENT_ROLE_MAPPING_PATH + clientId;
         return keycloakMohExternalApiCaller.get(path, null);
     }
 
     public ResponseEntity<Object> getAvailableUserClientRoleMappings(String userId, String clientId) {
-        String path = usersPath + "/" + userId + userClientRoleMappingPath + clientId + "/available";
+        String path = USERS_PATH + "/" + userId + USER_CLIENT_ROLE_MAPPING_PATH + clientId + "/available";
         return keycloakMohExternalApiCaller.get(path, null);
     }
 
     public ResponseEntity<Object> getEffectiveUserClientRoleMappings(String userId, String clientId) {
-        String path = usersPath + "/" + userId + userClientRoleMappingPath + clientId + "/composite";
+        String path = USERS_PATH + "/" + userId + USER_CLIENT_ROLE_MAPPING_PATH + clientId + "/composite";
         return keycloakMohExternalApiCaller.get(path, null);
     }
 
     public ResponseEntity<Object> addUserClientRole(String userId, String clientId, Object data) {
-        String path = usersPath + "/" + userId + userClientRoleMappingPath + clientId;
+        String path = USERS_PATH + "/" + userId + USER_CLIENT_ROLE_MAPPING_PATH + clientId;
         return keycloakMohExternalApiCaller.post(path, data);
     }
 
     public ResponseEntity<Object> deleteUserClientRole(String userId, String clientId, Object data) {
-        String path = usersPath + "/" + userId + userClientRoleMappingPath + clientId;
+        String path = USERS_PATH + "/" + userId + USER_CLIENT_ROLE_MAPPING_PATH + clientId;
         return keycloakMohExternalApiCaller.delete(path, data);
     }
 
     public ResponseEntity<Object> getUserGroups(String userId) {
-        String path = usersPath + "/" + userId + groupsPath;
+        String path = USERS_PATH + "/" + userId + GROUPS_PATH;
         return keycloakMohExternalApiCaller.get(path, null);
     }
 
     public ResponseEntity<Object> addUserGroups(String userId, String groupId) {
-        String path = usersPath + "/" + userId + groupsPath + "/" + groupId;
+        String path = USERS_PATH + "/" + userId + GROUPS_PATH + "/" + groupId;
         return keycloakMohExternalApiCaller.put(path);
     }
 
     public ResponseEntity<Object> removeUserGroups(String userId, String groupId) {
-        String path = usersPath + "/" + userId + groupsPath + "/" + groupId;
+        String path = USERS_PATH + "/" + userId + GROUPS_PATH + "/" + groupId;
         return keycloakMohExternalApiCaller.delete(path);
     }
 
@@ -174,7 +174,7 @@ public class KeycloakApiService {
     }
 
     public ResponseEntity<Object> removeUserIdentityProviderLink(String userId, String identityProvider, String userIdIdpRealm) {
-        String path = usersPath + "/" + userId + identityProviderLinksPath + "/" + identityProvider;
+        String path = USERS_PATH + "/" + userId + IDENTITY_PROVIDER_LINKS_PATH + "/" + identityProvider;
         ResponseEntity<Object> deleteIDPLinkResponse = keycloakMohExternalApiCaller.delete(path);
         if (identityProviderLinkDeletedSuccessfully(deleteIDPLinkResponse)) {
             // Some BCSC users can have an IDP alias that does not match the "bcsc" IDP realm (e.g. "bcsc_mspdirect") 
@@ -189,7 +189,7 @@ public class KeycloakApiService {
     }
 
     private ResponseEntity<Object> deleteUserFromIdpRealm(String userIdIdpRealm, String identityProvider) {
-        String path = "/" + identityProvider + usersPath + "/" + userIdIdpRealm;
+        String path = "/" + identityProvider + USERS_PATH + "/" + userIdIdpRealm;
         return keycloakMasterExternalApiCaller.delete(path);
     }
 

--- a/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
@@ -345,6 +345,38 @@ public class MoHUmsIntegrationTests {
     }
 
     @Test
+    public void searchByUserNameForServiceAccountUsers() {
+
+        final List<Object> usersResponse = webTestClient
+                .get()
+                .uri(
+                        uriBuilder -> uriBuilder
+                                .path("/users")
+                                .queryParam("username", "service-account-")
+                                .build()
+                )
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(Object.class)
+                .returnResult()
+                .getResponseBody();
+
+        Assertions.assertThat(usersResponse).isEmpty();
+    }
+
+    @Test
+    public void lookupServiceAccountUser() {
+        String UMS_SERVICE_ACCOUNT_ID = "7c5ddf30-1754-490b-ae43-ba71cd544e6b";
+        webTestClient
+                .get()
+                .uri(String.format("/users/%s", UMS_SERVICE_ACCOUNT_ID))
+                .header("Authorization", "Bearer " + jwt)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
+    @Test
     public void lookupUserAuthorized() throws Exception {
         webTestClient
                 .get()

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -1,3 +1,4 @@
+import router from "../router";
 import { umsRequest } from "./Repository";
 
 const resource = "/users";
@@ -19,9 +20,26 @@ export default {
   },
 
   getUser(userId) {
-    return umsRequest().then((axiosInstance) =>
-      axiosInstance.get(`${resource}/${userId}`)
-    );
+    return umsRequest().then((axiosInstance) => {
+      axiosInstance.interceptors.response.use(null, (error) => {
+        switch (error.response.status) {
+          case 403:
+            router.replace({
+              path: "/unauthorized",
+            });
+
+            break;
+          case 404:
+            router.replace({
+              path: "/notFound",
+            });
+            break;
+        }
+        return Promise.reject(error);
+      });
+
+      return axiosInstance.get(`${resource}/${userId}`);
+    });
   },
 
   createUser(content) {

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -27,7 +27,6 @@ export default {
             router.replace({
               path: "/unauthorized",
             });
-
             break;
           case 404:
             router.replace({


### PR DESCRIPTION
See details:
https://dev.azure.com/cgi-vic-hlth/AM%20Team/_sprints/taskboard/AM%20Team/AM%20Team/Sprint%2085?workitem=9969

Advanced search: filtering out service accounts from result list.
Direct API call: return 403 forbidden
Updated error handling for /users API call