### PR TITLE
AB#10162: Fix for UMC - Active User Count metrics query showing moh_applications_realm* clients under bcsc realm

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/MetricsController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/MetricsController.java
@@ -50,8 +50,8 @@ public class MetricsController {
                 + "       AND ue.enabled = 1"
                 + "       AND kcr.id IS NULL"
                 + " )"
-                + " WHERE NOT (client_id IN ('USER-MANAGEMENT-SERVICE', 'PRIME-WEBAPP-ENROLLMENT')"
-                + "          OR LOWER(client_id) LIKE '%account%' OR LOWER(client_id) LIKE '%console%' OR LOWER(client_id) LIKE '%realm%')"
+                + " WHERE NOT (client_id IN ('account', 'account-console', 'security-admin-console', 'JAVASCRIPT_CONSOLE', 'USER-MANAGEMENT-SERVICE', 'PRIME-WEBAPP-ENROLLMENT')"
+                + "          OR LOWER(client_id) LIKE '%realm%')"
                 + " GROUP BY realm_id, client_id, description"
                 + " ORDER BY realm_id ASC, client_id ASC";
 

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/MetricsController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/MetricsController.java
@@ -50,8 +50,8 @@ public class MetricsController {
                 + "       AND ue.enabled = 1"
                 + "       AND kcr.id IS NULL"
                 + " )"
-                + " WHERE NOT (client_id = 'account' AND (LOWER(realm_id) IN ('bceid_basic', 'bceid_business', 'bcprovider_aad', 'bcsc', 'idir', 'idir_aad', 'master', 'moh_applications', 'moh_citizen', 'moh_idp', 'phsa', 'phsa_aad'))"
-                + "          OR (client_id IN ('realm-management', 'USER-MANAGEMENT-SERVICE', 'PRIME-WEBAPP-ENROLLMENT')))"
+                + " WHERE NOT (client_id IN ('USER-MANAGEMENT-SERVICE', 'PRIME-WEBAPP-ENROLLMENT')"
+                + "          OR LOWER(client_id) LIKE '%account%' OR LOWER(client_id) LIKE '%console%' OR LOWER(client_id) LIKE '%realm%')"
                 + " GROUP BY realm_id, client_id, description"
                 + " ORDER BY realm_id ASC, client_id ASC";
 


### PR DESCRIPTION
See https://dev.azure.com/cgi-vic-hlth/AM%20Team/_workitems/edit/10162 for more details.

Went a bit off the rails to filter out all system-ish clients like the following,
- account
- account-console
- JAVASCRIPT_CONSOLE
- lra_realm
- master_realm
- MoHApplicationRealm_ldap
- moh_applications_realm
- moh_applications_realm_hcap
- moh_applications_realm_mspdirect
- moh_applications_realm_prime
- moh_citizen_realm
- security-admin-console