### PR TITLE
Added trim to all input fields.

### DIFF
--- a/frontend/src/components/OrganizationsCreate.vue
+++ b/frontend/src/components/OrganizationsCreate.vue
@@ -11,7 +11,7 @@
               dense
               outlined
               id="id"
-              v-model="organization.organizationId"
+              v-model.trim="organization.organizationId"
               required
               :rules="[
                 (v) => !!v || 'ID is required',
@@ -26,7 +26,7 @@
               dense
               outlined
               id="name"
-              v-model="organization.name"
+              v-model.trim="organization.name"
               required
               :rules="[
                 (v) => !!v || 'Organization Name is required',

--- a/frontend/src/components/OrganizationsSearch.vue
+++ b/frontend/src/components/OrganizationsSearch.vue
@@ -17,7 +17,7 @@
           id="organization-search"
           outlined
           dense
-          v-model="organizationSearchInput"
+          v-model.trim="organizationSearchInput"
           placeholder="Organization ID"
         />
       </v-col>
@@ -63,7 +63,7 @@
               dense
               outlined
               id="ID"
-              v-model="organizationToEdit.organizationId"
+              v-model.trim="organizationToEdit.organizationId"
             ></v-text-field>
 
             <label for="name" class="required">Organization Name</label>
@@ -71,7 +71,7 @@
               dense
               outlined
               id="name"
-              v-model="organizationToEdit.name"
+              v-model.trim="organizationToEdit.name"
               required
               :rules="[
                 (v) => !!v || 'Organization Name is required',

--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -106,7 +106,7 @@
               outlined
               :disabled="!editUserDetailsPermission"
               id="first-name"
-              v-model="user.firstName"
+              v-model.trim="user.firstName"
               required
               :rules="[(v) => !!v || 'First Name is required']"
             />
@@ -123,7 +123,7 @@
               outlined
               :disabled="!editUserDetailsPermission"
               id="last-name"
-              v-model="user.lastName"
+              v-model.trim="user.lastName"
               required
               :rules="[(v) => !!v || 'Last Name is required']"
             />
@@ -140,7 +140,7 @@
               outlined
               :disabled="!editUserDetailsPermission"
               id="email"
-              v-model="user.email"
+              v-model.trim="user.email"
               required
               :rules="emailRules"
               type="email"
@@ -154,7 +154,7 @@
               outlined
               :disabled="!editUserDetailsPermission"
               id="phone"
-              v-model="user.attributes.phone"
+              v-model.trim="user.attributes.phone"
             />
 
             <label :disabled="!editUserDetailsPermission" for="org-details">

--- a/frontend/src/components/UserSearch.vue
+++ b/frontend/src/components/UserSearch.vue
@@ -26,7 +26,7 @@
           id="user-search"
           outlined
           dense
-          v-model="userSearchInput"
+          v-model.trim="userSearchInput"
           placeholder="Username, email, name, or ID"
           @keyup.enter="
             searchUser('&search=' + userSearchInput.replaceAll('\\', '%5C'))
@@ -97,7 +97,7 @@
           id="adv-search-last-name"
           outlined
           dense
-          v-model="lastNameInput"
+          v-model.trim="lastNameInput"
           @keyup.enter="searchUser(advancedSearchParams)"
         />
       </v-col>
@@ -107,7 +107,7 @@
           id="adv-search-first-name"
           outlined
           dense
-          v-model="firstNameInput"
+          v-model.trim="firstNameInput"
           @keyup.enter="searchUser(advancedSearchParams)"
         />
       </v-col>
@@ -117,7 +117,7 @@
           id="adv-search-username"
           outlined
           dense
-          v-model="usernameInput"
+          v-model.trim="usernameInput"
           @keyup.enter="searchUser(advancedSearchParams)"
         />
       </v-col>
@@ -127,7 +127,7 @@
           id="adv-search-email"
           outlined
           dense
-          v-model="emailInput"
+          v-model.trim="emailInput"
           @keyup.enter="searchUser(advancedSearchParams)"
         />
       </v-col>
@@ -167,7 +167,7 @@
         >
           <template v-slot:activator="{ on, attrs }">
             <v-text-field
-              v-model="lastLogDate"
+              v-model.trim="lastLogDate"
               id="last-log-date"
               v-bind="attrs"
               v-on="on"
@@ -346,8 +346,8 @@
 </template>
 
 <script>
-  import UsersRepository from "@/api/UsersRepository";
   import ClientsRepository from "@/api/ClientsRepository";
+  import UsersRepository from "@/api/UsersRepository";
 
   const options = { dateStyle: "short" };
   const formatDate = new Intl.DateTimeFormat("en-CA", options).format;


### PR DESCRIPTION
A few notes:

1. For consistency's sake, trim was added to organizationId in OrganizationsSearch even thought it's disabled.
2. The trim modifier does not work on textareas. Given that there is only a single textarea (User notes) and it's essentially for internal (team) usage, it's not worth implementing a custom solution to trim data.
3. The UserDetails component is not actually re-rendered after a Create/Update. So the fields still show the original untrimmed value. This means that the persisted state of the data isn't exactly as what's onscreen but this is pretty minor as a) it would just be trimmed again on save and b) it's unlikely users will be making additional modifications right after an Update. If we wanted to re-render the component there are ways to do so using component keys.