### PR TITLE
update IDP name mappings

### DIFF
--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -423,16 +423,17 @@
         let formattedIdentityProviders = {
           bceid_business: "BCeID Business",
           bcprovider_aad: "BC Provider",
-          bcsc: "BC Services Card for PIdP",
-          bcsc_mspdirect: "BC Services Card for MSPDirect",
-          bcsc_prime: "BC Services Card for PRIME",
-          bcsc_hcap: "BC Services Card for HCAP",
           idir: "IDIR",
           idir_aad: "IDIR AzureAD",
           moh_idp: "Keycloak",
           phsa: "Health Authority",
           phsa_aad: "Health Authority AzureAD",
         };
+
+        if (idp.startsWith("bcsc")) {
+          return "BC Services Card";
+        }
+
         return formattedIdentityProviders[idp] || idp;
       },
     },

--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -421,12 +421,17 @@
       // Formatted to match standard naming conventions
       formatIdentityProvider: function (idp) {
         let formattedIdentityProviders = {
-          phsa: "Health Authority",
-          moh_idp: "MoH LDAP",
+          bceid_business: "BCeID Business",
+          bcprovider_aad: "BC Provider",
+          bcsc: "BC Services Card for PIdP",
+          bcsc_mspdirect: "BC Services Card for MSPDirect",
+          bcsc_prime: "BC Services Card for PRIME",
+          bcsc_hcap: "BC Services Card for HCAP",
           idir: "IDIR",
           idir_aad: "IDIR AzureAD",
-          bceid: "BCeID",
-          bcsc: "BCSC",
+          moh_idp: "Keycloak",
+          phsa: "Health Authority",
+          phsa_aad: "Health Authority AzureAD",
         };
         return formattedIdentityProviders[idp] || idp;
       },


### PR DESCRIPTION
See https://dev.azure.com/cgi-vic-hlth/AM%20Team/_sprints/taskboard/AM%20Team/AM%20Team/Sprint%2089?workitem=10358 for details.

The mapping is hardcoded, following the previous solution. It would be possible to utilize the Keycloak API to return `Display Name` of the federated Identity Provider.