### PR TITLE
Bcmoham 13875 last logon date not working in keycloak report

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
@@ -72,21 +72,21 @@ public class UsersController {
 
     /**
      * 
-     * @param briefRepresentation
-     * @param email
-     * @param first
-     * @param firstName
-     * @param lastName
-     * @param max
-     * @param search
-     * @param username
-     * @param org
-     * @param lastLogAfter
-     * @param lastLogBefore
+     * @param briefRepresentation indicates if a brief representation of the client should be returned by the Keycloak API get Users 
+     * @param email the email of the user
+     * @param first the pagination offset for the Keycloak api get Users
+     * @param firstName the first name of the user
+     * @param lastName the last name of the user
+     * @param max the maximum results size to be returned by the Keycloak API get Users
+     * @param search a String contained in username, first or last name, or email of the user
+     * @param username  the username of the user
+     * @param org the ID of an Organization the user is associated to
+     * @param lastLogAfter the date after which the user logged in 
+     * @param lastLogBefore the date before which the user logged in
      * @param clientId	the Id, which is a UUID, of the Client entity, maps to keycloak.client.id in the keycloak database model e.g. b3cfa2d4-42e7-46d1-b67f-b52e9389185b
      * @param clientClientId the Client Id of the Client entity, maps to keycloak.client.clienId in the keycloak database model e.g. SA-HIBC-SERVICE-BC-PORTAL
-     * @param selectedRoles
-     * @return
+     * @param selectedRoles the roles the user must have, an empty list means all role for that client will be used
+     * @return a list of Users that match the specified criteria
      */
     @GetMapping("/users")
     public ResponseEntity<List<Object>> getUsers(

--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/controller/UsersController.java
@@ -79,12 +79,12 @@ public class UsersController {
      * @param lastName the last name of the user
      * @param max the maximum results size to be returned by the Keycloak API get Users
      * @param search a String contained in username, first or last name, or email of the user
-     * @param username  the username of the user
+     * @param username the username of the user
      * @param org the ID of an Organization the user is associated to
      * @param lastLogAfter the date after which the user logged in 
      * @param lastLogBefore the date before which the user logged in
-     * @param clientId	the Id, which is a UUID, of the Client entity, maps to keycloak.client.id in the keycloak database model e.g. b3cfa2d4-42e7-46d1-b67f-b52e9389185b
-     * @param clientClientId the Client Id of the Client entity, maps to keycloak.client.clienId in the keycloak database model e.g. SA-HIBC-SERVICE-BC-PORTAL
+     * @param clientId	the Id, which is a UUID, of the Client entity, maps to keycloak.client.id in the keycloak database model
+     * @param clientClientId the Client Id of the Client entity, maps to keycloak.client.clientId in the keycloak database model
      * @param selectedRoles the roles the user must have, an empty list means all role for that client will be used
      * @return a list of Users that match the specified criteria
      */

--- a/frontend/src/components/UserSearch.vue
+++ b/frontend/src/components/UserSearch.vue
@@ -423,8 +423,8 @@
             if (client.id == this.selectedClientId) {
               params = this.addQueryParameter(
                 params,
-                "clientName",
-                client.name
+                "clientClientId",
+                client.clientId
               );
             }
           });


### PR DESCRIPTION
Updated the Advanced Search to use the client id instead of client name as search criteria because that is what is stored in the tables that it searches against. i.e. event_entity and client.