### PR TITLE
Basic search and sort fix

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/userSearch/user/UserSpecifications.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/userSearch/user/UserSpecifications.java
@@ -44,7 +44,7 @@ public class UserSpecifications {
 
     /**
    To keep the basic search functionality intact, most of the logic is copied from this class:
-   https://github.com/keycloak/keycloak/blob/main/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+     https://github.com/keycloak/keycloak/blob/24.0.4/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
    The method splits the input value and compares each part of it with first name, last name, email and username.
      @param searchValue A String contained in username, first or last name, or email. Default search behavior is prefix-based (e.g., foo or foo*). Use foo for infix search and &quot;foo&quot; for exact search.
      */

--- a/frontend/src/components/UserSearch.vue
+++ b/frontend/src/components/UserSearch.vue
@@ -578,7 +578,9 @@
         return role;
       },
       setSearchResults(results) {
-        this.searchResults = results;
+        this.searchResults = results.sort((a, b) =>
+          a.username.localeCompare(b.username)
+        );
       },
       handleError(message, error) {
         this.$store.commit("alert/setAlert", {


### PR DESCRIPTION
### Changes being made

Add default sorting on frontend. Fix basic search so it behaves as when calling Keycloak API.

### Context

Following the deployment to Production, one of the administrators mentioned that the basic search is not working as previously.

### Quality Check

- [x] E2E/ Unit/ Integration tests have been added.
- [x] Frontend tests have been successfully run.
- [x] Backend tests have been successfully run.
- [x] The actual changes are separated from formatting changes.
