### PR TITLE
fix basic search

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/userSearch/user/UserSpecifications.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/userSearch/user/UserSpecifications.java
@@ -52,13 +52,13 @@ public class UserSpecifications {
         return (root, query, criteriaBuilder) -> {
             List<Predicate> searchPredicates = new ArrayList<>();
             for (String value : searchValue.trim().split("\\s+")) {
-                searchPredicates.addAll(getSearchPredicateArray(value, root, criteriaBuilder));
+                searchPredicates.add(criteriaBuilder.or(getSearchPredicateArray(value, root, criteriaBuilder)));
             }
-            return criteriaBuilder.or(searchPredicates.toArray(new Predicate[0]));
+            return criteriaBuilder.and(searchPredicates.toArray(new Predicate[0]));
         };
     }
 
-    private List<Predicate> getSearchPredicateArray(String value, Root<UserEntity> root, CriteriaBuilder criteriaBuilder){
+    private Predicate[] getSearchPredicateArray(String value, Root<UserEntity> root, CriteriaBuilder criteriaBuilder){
         value = value.toLowerCase();
 
         List<Predicate> orPredicates = new ArrayList<>();
@@ -81,7 +81,7 @@ public class UserSpecifications {
             orPredicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("firstName")), value, ESCAPE_BACKSLASH));
             orPredicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("lastName")), value, ESCAPE_BACKSLASH));
         }
-        return orPredicates;
+        return orPredicates.toArray(new Predicate[0]);
     }
 
 


### PR DESCRIPTION
### Changes being made

Fix usersParamsLike Specification method. 

### Context

The OR clauses were not nested inside AND which resulted in returning bigger result sets than expected. Basic search for "Filip Adam" would return all users whose:
(first name OR last name OR email OR username CONTAINS "Adam") **OR** (first name OR last name OR email OR username CONTAINS "Filip")
instead of:
(first name OR last name OR email OR username CONTAINS "Adam") **AND** (first name OR last name OR email OR username CONTAINS "Filip")


### Quality Check

- [x] E2E/ Unit/ Integration tests have been added.
- [x] Frontend tests have been successfully run.
- [x] Backend tests have been successfully run.
- [x] The actual changes are separated from formatting changes.
