### PR TITLE
add alias mapping for PHO-RSC clients

### DIFF
--- a/frontend/src/api/ClientsRepository.js
+++ b/frontend/src/api/ClientsRepository.js
@@ -22,4 +22,20 @@ export default {
       )
     );
   },
+
+  assignClientAliases(clients) {
+    let clientAliases = [
+      { clientId: "PHO-RSC", alias: "POSIT-USER-ROLES" },
+      { clientId: "PHO-RSC-GROUPS", alias: "POSIT-GROUP-ROLES" },
+    ];
+    return clients.map((client) => {
+      const aliasMapping = clientAliases.find(
+        (clientAlias) => clientAlias.clientId === client.clientId
+      );
+      if (aliasMapping) {
+        return { ...client, clientId: aliasMapping.alias };
+      }
+      return client;
+    });
+  },
 };

--- a/frontend/src/api/ClientsRepository.js
+++ b/frontend/src/api/ClientsRepository.js
@@ -23,13 +23,14 @@ export default {
     );
   },
 
+  clientAliases: [
+    { clientId: "PHO-RSC", alias: "POSIT-USER-ROLES" },
+    { clientId: "PHO-RSC-GROUPS", alias: "POSIT-GROUP-ROLES" },
+  ],
+
   assignClientAliases(clients) {
-    let clientAliases = [
-      { clientId: "PHO-RSC", alias: "POSIT-USER-ROLES" },
-      { clientId: "PHO-RSC-GROUPS", alias: "POSIT-GROUP-ROLES" },
-    ];
     return clients.map((client) => {
-      const aliasMapping = clientAliases.find(
+      const aliasMapping = this.clientAliases.find(
         (clientAlias) => clientAlias.clientId === client.clientId
       );
       if (aliasMapping) {

--- a/frontend/src/api/GroupsRepository.js
+++ b/frontend/src/api/GroupsRepository.js
@@ -1,3 +1,4 @@
+import ClientsRepository from "./ClientsRepository";
 import { umsRequest } from "./Repository";
 
 const resource = "/groups";
@@ -15,10 +16,7 @@ export default {
     }
   },
   modifyGroupDescriptions(groups) {
-    let clientAliases = [
-      { clientId: "PHO-RSC", alias: "POSIT-USER-ROLES" },
-      { clientId: "PHO-RSC-GROUPS", alias: "POSIT-GROUP-ROLES" },
-    ];
+    let clientAliases = ClientsRepository.clientAliases;
 
     return groups.map((group) => {
       let newDescription = group.description;

--- a/frontend/src/api/GroupsRepository.js
+++ b/frontend/src/api/GroupsRepository.js
@@ -14,4 +14,24 @@ export default {
       );
     }
   },
+  modifyGroupDescriptions(groups) {
+    let clientAliases = [
+      { clientId: "PHO-RSC", alias: "POSIT-USER-ROLES" },
+      { clientId: "PHO-RSC-GROUPS", alias: "POSIT-GROUP-ROLES" },
+    ];
+
+    return groups.map((group) => {
+      let newDescription = group.description;
+      clientAliases.forEach((alias) => {
+        newDescription = newDescription.replace(
+          alias.clientId.toLowerCase(),
+          alias.alias.toLowerCase()
+        );
+      });
+      return {
+        ...group,
+        description: newDescription,
+      };
+    });
+  },
 };

--- a/frontend/src/components/UserSearch.vue
+++ b/frontend/src/components/UserSearch.vue
@@ -544,7 +544,10 @@
       loadClients: function () {
         return ClientsRepository.get()
           .then((response) => {
-            this.clients.push(...response.data);
+            const clientsWithAliases = ClientsRepository.assignClientAliases(
+              response.data
+            );
+            this.clients.push(...clientsWithAliases);
           })
           .catch((error) => {
             this.handleError("Client search failed", error);

--- a/frontend/src/components/UserUpdateGroups.vue
+++ b/frontend/src/components/UserUpdateGroups.vue
@@ -39,8 +39,8 @@
 </template>
 
 <script>
-  import UsersRepository from "@/api/UsersRepository";
   import GroupsRepository from "@/api/GroupsRepository";
+  import UsersRepository from "@/api/UsersRepository";
 
   export default {
     name: "UserUpdateGroups",
@@ -102,7 +102,9 @@
         });
         // Keycloak "Groups" API returns a different object structure than users/groups
         // We need them to match for the checkboxes to map
-        const allGroups = userGroupResponses[1].data;
+        const allGroups = GroupsRepository.modifyGroupDescriptions(
+          userGroupResponses[1].data
+        );
         const searchedUserGroups = userGroupResponses[0].data.map(
           ({ id, name, path }) => ({
             id,

--- a/frontend/src/components/UserUpdateRoles.vue
+++ b/frontend/src/components/UserUpdateRoles.vue
@@ -327,8 +327,11 @@
         });
 
         ClientsRepository.get().then((allClients) => {
+          const allClientsWithAliases = ClientsRepository.assignClientAliases(
+            allClients.data
+          );
           Promise.all(
-            allClients.data.map((client) => {
+            allClientsWithAliases.map((client) => {
               return UsersRepository.getUserEffectiveClientRoles(
                 this.userId,
                 client.id


### PR DESCRIPTION
### Changes being made

Added a function in ClientRepository.js that swaps clientId to defined alias, for PHO-RSC and PHO-RSC-GROUPS clients.

### Context

This is a UI change only, following the Advanced Search upgrade, all the API calls are using ID instead of clientID.
PHO-RSC client is rebranding, referenced as Posit from now on. The client request was to map the name in dropdowns from:
PHO-RSC ->POSIT-USER-ROLES
PHO-RSC -> POSIT-GROUP-ROLES

### Quality Check

- [x] E2E/ Unit/ Integration tests have been added.
- [x] Frontend tests have been successfully run.
- [x] Backend tests have been successfully run.
- [x] The actual changes are separated from formatting changes.
