### PR TITLE
Umc last login and group description fix

### DIFF
--- a/frontend/src/api/ClientsRepository.js
+++ b/frontend/src/api/ClientsRepository.js
@@ -23,6 +23,11 @@ export default {
     );
   },
 
+  /**
+   * Some clients request that their application is referred by different name than Keycloak's Client Id
+   * Because changing Client Id requires updating authentication flow on the client side, UMC client aliases are intorduced.
+   * Define entry in the below array to display alias instead of clientID for a given client.
+   */
   clientAliases: [
     { clientId: "PHO-RSC", alias: "POSIT-USER-ROLES" },
     { clientId: "PHO-RSC-GROUPS", alias: "POSIT-GROUP-ROLES" },

--- a/frontend/src/api/ClientsRepository.js
+++ b/frontend/src/api/ClientsRepository.js
@@ -24,8 +24,8 @@ export default {
   },
 
   /**
-   * Some clients request that their application is referred by different name than Keycloak's Client Id
-   * Because changing Client Id requires updating authentication flow on the client side, UMC client aliases are intorduced.
+   * Some clients request that their application is referred to by a different name than Keycloak's Client Id
+   * Because changing Client Id requires updating authentication flow on the client side, UMC client aliases are introduced.
    * Define entry in the below array to display alias instead of clientID for a given client.
    */
   clientAliases: [

--- a/frontend/src/api/GroupsRepository.js
+++ b/frontend/src/api/GroupsRepository.js
@@ -17,11 +17,13 @@ export default {
   },
   modifyGroupDescriptions(groups) {
     let clientAliases = ClientsRepository.clientAliases;
-
     return groups.map((group) => {
       let newDescription = group.description;
       clientAliases.forEach((alias) => {
-        let regex = new RegExp(`\\b${alias.clientId.toLowerCase()}\\b`, "g");
+        let regex = new RegExp(
+          `(?<!\\w|-)${alias.clientId.toLowerCase()}(?!\\w|-)`,
+          "g"
+        );
         newDescription = newDescription.replace(
           regex,
           alias.alias.toLowerCase()

--- a/frontend/src/api/GroupsRepository.js
+++ b/frontend/src/api/GroupsRepository.js
@@ -21,8 +21,9 @@ export default {
     return groups.map((group) => {
       let newDescription = group.description;
       clientAliases.forEach((alias) => {
+        let regex = new RegExp(`\\b${alias.clientId.toLowerCase()}\\b`, "g");
         newDescription = newDescription.replace(
-          alias.clientId.toLowerCase(),
+          regex,
           alias.alias.toLowerCase()
         );
       });

--- a/frontend/src/api/GroupsRepository.js
+++ b/frontend/src/api/GroupsRepository.js
@@ -15,11 +15,21 @@ export default {
       );
     }
   },
+  /**
+   * This function transforms group descriptions.
+   * It swaps references to clientID with aliases, defined in ClientsRepository.clientAliases.
+   * For example "Manage pho-rsc -> Manage posit-user-roles"
+   */
   modifyGroupDescriptions(groups) {
     let clientAliases = ClientsRepository.clientAliases;
     return groups.map((group) => {
       let newDescription = group.description;
       clientAliases.forEach((alias) => {
+        /**
+         * Group descriptions can contain "-" which are not treated as word characters. For example "Manage pho-rsc".
+         * Negative Lookbehind (?<!\\w|-): This ensures that the clientId is not preceded by a word character (letters, digits, underscores) or a hyphen.
+         * Negative Lookahead (?!\\w|-): This ensures that the clientId is not followed by a word character or a hyphen.
+         */
         let regex = new RegExp(
           `(?<!\\w|-)${alias.clientId.toLowerCase()}(?!\\w|-)`,
           "g"

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -1,4 +1,5 @@
 import router from "../router";
+import ClientsRepository from "./ClientsRepository";
 import { umsRequest } from "./Repository";
 
 const resource = "/users";
@@ -152,5 +153,19 @@ export default {
         headers: { "Content-Type": "text/plain" },
       })
     );
+  },
+  mapClientAliasesOfLastLogins(lastLogins) {
+    console.log(lastLogins);
+    let clientAliases = ClientsRepository.clientAliases;
+    for (const [key, value] of Object.entries(lastLogins)) {
+      const aliasMapping = clientAliases.find(
+        (clientAlias) => clientAlias.clientId === key
+      );
+      if (aliasMapping) {
+        lastLogins[aliasMapping.alias] = value;
+        delete lastLogins[key];
+      }
+    }
+    return lastLogins;
   },
 };

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -155,7 +155,6 @@ export default {
     );
   },
   mapClientAliasesOfLastLogins(lastLogins) {
-    console.log(lastLogins);
     let clientAliases = ClientsRepository.clientAliases;
     for (const [key, value] of Object.entries(lastLogins)) {
       const aliasMapping = clientAliases.find(

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -154,6 +154,12 @@ export default {
       })
     );
   },
+  /**
+   * This function transforms last-logins object.
+   * It swaps references to clientID with aliases, defined in ClientsRepository.clientAliases.
+   * For example "PHO-RSC": 1711383701558 -> "PHO-USER-ROLES": 1711383701558
+   * This is required, so that Last Log In field is populated in Update User Roles component.
+   */
   mapLastLoginsClientAliases(lastLogins) {
     let clientAliases = ClientsRepository.clientAliases;
     for (const [key, value] of Object.entries(lastLogins)) {

--- a/frontend/src/api/UsersRepository.js
+++ b/frontend/src/api/UsersRepository.js
@@ -154,7 +154,7 @@ export default {
       })
     );
   },
-  mapClientAliasesOfLastLogins(lastLogins) {
+  mapLastLoginsClientAliases(lastLogins) {
     let clientAliases = ClientsRepository.clientAliases;
     for (const [key, value] of Object.entries(lastLogins)) {
       const aliasMapping = clientAliases.find(

--- a/frontend/src/components/UserUpdateRoles.vue
+++ b/frontend/src/components/UserUpdateRoles.vue
@@ -323,7 +323,7 @@
         let clientsNoRolesAssigned = [];
 
         UsersRepository.getUserLogins(this.userId).then((lastLogins) => {
-          lastLoginMap = UsersRepository.mapClientAliasesOfLastLogins(
+          lastLoginMap = UsersRepository.mapLastLoginsClientAliases(
             lastLogins.data
           );
         });

--- a/frontend/src/components/UserUpdateRoles.vue
+++ b/frontend/src/components/UserUpdateRoles.vue
@@ -323,7 +323,9 @@
         let clientsNoRolesAssigned = [];
 
         UsersRepository.getUserLogins(this.userId).then((lastLogins) => {
-          lastLoginMap = lastLogins.data;
+          lastLoginMap = UsersRepository.mapClientAliasesOfLastLogins(
+            lastLogins.data
+          );
         });
 
         ClientsRepository.get().then((allClients) => {
@@ -344,11 +346,10 @@
             .then((rolesArray) => {
               rolesArray.forEach((clientRoles) => {
                 if (clientRoles.data.length > 0) {
-                  let lastLoginStr = LAST_LOGIN_NOT_RECORDED;
-                  if (lastLoginMap[clientRoles.clientRepresentation.name]) {
-                    lastLoginStr =
-                      lastLoginMap[clientRoles.clientRepresentation.name];
-                  }
+                  let lastLoginStr =
+                    lastLoginMap[clientRoles.clientRepresentation.clientId] ||
+                    LAST_LOGIN_NOT_RECORDED;
+
                   clientRoles.roleArray = [];
                   clientRoles.data.forEach((role) => {
                     clientRoles.roleArray.push(role.name);


### PR DESCRIPTION
### Changes being made

1. Fix group description mapping in UMC.
2. Added User Last Login for client aliases, so that the date displays in "User Details" page.
3. Fix last login date display (https://dev.azure.com/cgi-vic-hlth/AM%20Team/_sprints/taskboard/AM%20Team/AM%20Team/Sprint%20105?workitem=11114)

### Context

1. Issue with group description mapping was caused by how String.replace() is executed. Solution was to create regex. 
  Could not use `\\b` character (word boundary) as it includes only letters, numbers and underscore. The client aliases can include also `-` that's why regex is checking for this `(?!\\w|-)`
  So description would look like this:
  ![image](https://github.com/bcgov/moh-keycloak-user-management/assets/52381251/7ab0b76b-65b6-4fe5-99d1-c89fceec9b45)
  Instead of this:
  ![image](https://github.com/bcgov/moh-keycloak-user-management/assets/52381251/996eb3d5-90cb-4d9b-aa54-066c6bf1c923)

2. User last login was not displaying in user details page for clients with aliases (POSIT), because alias was not mapped to the LastLogin object.

3. Last login was not showing up because UMS returns <client id, timestamp> and UMC expected <client name, timestamp>

### Quality Check

- [x] The actual changes are separated from formatting changes.
- [x] Frontend tests have been successfully run.
- [N/A] Backend tests have been successfully run.
 - [N/A] E2E/ Unit/ Integration tests have been added.

