### PR TITLE
update phsa tooltip

### DIFF
--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -32,6 +32,15 @@
                         <span class="tooltip-note">
                           Note: The username will already contain an '@domain'
                           that the '{{ idp.alias }}' will be appended to.
+                          <br />
+                          <span
+                            class="tooltip-note"
+                            v-if="idp.alias === '@phsa'"
+                          >
+                            This applies to all Health Authority users, for
+                            example: username@interiorhealth.ca@phsa or
+                            username@phsa.ca@phsa
+                          </span>
                         </span>
                       </template>
                     </template>
@@ -241,22 +250,12 @@
           },
           { name: "BC Services Card", suffix: true, alias: "@bcsc" },
           { name: "FNHA", suffix: true, alias: "@fnha", domainNote: true },
-          { name: "Fraser Health", suffix: false, alias: "sfhr\\" },
-          { name: "Interior Health", suffix: false, alias: "iha\\" },
-          { name: "Northern Health", suffix: false, alias: "nirhb\\" },
-          { name: "Providence Health Care", suffix: false, alias: "infosys\\" },
           {
-            name: "Provincial Health",
+            name: "Health Authority ID",
             suffix: true,
             alias: "@phsa",
             domainNote: true,
           },
-          {
-            name: "Vancouver Coastal Health",
-            suffix: false,
-            alias: ["vch\\", "vrhb\\"],
-          },
-          { name: "Vancouver Island Health", suffix: false, alias: "viha\\" },
         ],
         organizations: this.$organizations.map((item) => {
           item.value = `{"id":"${item.organizationId}","name":"${item.name}"}`;
@@ -445,25 +444,7 @@
         }
       },
       getTooltipUsername: function (identityProvider) {
-        const formatAlias = (alias, isSuffix) => {
-          return isSuffix
-            ? `username${alias.bold()}`
-            : `${alias.bold()}username`;
-        };
-
-        let usernameTooltip;
-        //if idp has an array of possible aliases
-        if (typeof identityProvider.alias === "object") {
-          usernameTooltip = identityProvider.alias
-            .map((alias) => formatAlias(alias, identityProvider.suffix))
-            .join(" or ");
-        } else {
-          usernameTooltip = formatAlias(
-            identityProvider.alias,
-            identityProvider.suffix
-          );
-        }
-        return usernameTooltip;
+        return `username${identityProvider.alias.bold()}`;
       },
     },
     filters: {

--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -454,11 +454,12 @@
         let formattedIdentityProviders = {
           bceid_business: "BCeID Business",
           bcprovider_aad: "BC Provider",
+          fnha_aad: "FNHA MFA",
           idir: "IDIR",
-          idir_aad: "IDIR AzureAD",
+          idir_aad: "IDIR MFA",
           moh_idp: "Keycloak",
-          phsa: "Health Authority",
-          phsa_aad: "Health Authority AzureAD",
+          phsa: "Health Authority ID",
+          phsa_aad: "Health Authority ID MFA",
         };
 
         if (idp.startsWith("bcsc")) {

--- a/frontend/src/components/UserDetails.vue
+++ b/frontend/src/components/UserDetails.vue
@@ -245,7 +245,12 @@
           { name: "Interior Health", suffix: false, alias: "iha\\" },
           { name: "Northern Health", suffix: false, alias: "nirhb\\" },
           { name: "Providence Health Care", suffix: false, alias: "infosys\\" },
-          { name: "Provincial Health", suffix: false, alias: "phsabc\\" },
+          {
+            name: "Provincial Health",
+            suffix: true,
+            alias: "@phsa",
+            domainNote: true,
+          },
           {
             name: "Vancouver Coastal Health",
             suffix: false,


### PR DESCRIPTION
### Changes being made

Update PHSA tooltip in UMC
Clean up frontend code, as tooltip processing logic for various health authority IDs is deprecated.

### Context

https://dev.azure.com/cgi-vic-hlth/AM%20Team/_sprints/taskboard/AM%20Team/AM%20Team/Sprint%20105?workitem=11094

### Quality Check

- [ N/A ] E2E/ Unit/ Integration tests have been added.
- [ x ] Frontend tests have been successfully run.
- [ N/A ] Backend tests have been successfully run.
- [ N/A ] The actual changes are separated from formatting changes.
