### PR TITLE
filter out client credentials from keycloak api response

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/KeycloakApiService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/mohums/webclient/KeycloakApiService.java
@@ -34,8 +34,20 @@ public class KeycloakApiService {
     }
 
     // Clients
+    @SuppressWarnings("unchecked")
     public ResponseEntity<List<Object>> getClients() {
-        return keycloakMohExternalApiCaller.getList(CLIENTS_PATH);
+        ResponseEntity<List<Object>> clientsResponse = keycloakMohExternalApiCaller.getList(CLIENTS_PATH);
+        if(clientsResponse.getStatusCode().is2xxSuccessful() && clientsResponse.hasBody()){
+            List<Object> clientsWithoutSecret = clientsResponse.getBody().stream()
+                    .map(client -> {
+                        LinkedHashMap<String, Object> clientMap = (LinkedHashMap<String, Object>) client;
+                        clientMap.remove("secret");
+                        return clientMap;
+                    })
+                    .collect(Collectors.toList());
+            clientsResponse = new ResponseEntity<>(clientsWithoutSecret, clientsResponse.getHeaders(), clientsResponse.getStatusCode());
+        }
+        return clientsResponse;
 
     }
 

--- a/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/mohums/integration/MoHUmsIntegrationTests.java
@@ -134,10 +134,14 @@ public class MoHUmsIntegrationTests {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void clientsAuthorized() throws Exception {
         List<Object> clients = getAll("clients");
 
         Assertions.assertThat(clients).isNotEmpty();
+        Assertions.assertThat(clients.stream()
+                .map(client -> (LinkedHashMap<String, Object>) client)
+                .noneMatch(client -> client.containsKey("secret"))).isTrue();
     }
 
     @Test


### PR DESCRIPTION
### Changes being made

Remove "secret" field from ClientRepresentation objects returned by Keycloak API.

### Context

As of Keycloak 22 a client secret is being returned in `/clients` API response.

### Quality Check

- [x] E2E/ Unit/ Integration tests have been added.
- [x] Frontend tests have been successfully run.
- [x] Backend tests have been successfully run.

