### PR TITLE
enforce idir mfa on UMC

### DIFF
--- a/frontend/src/keycloak/index.js
+++ b/frontend/src/keycloak/index.js
@@ -16,7 +16,7 @@ let initOptions = {
 let kcLogin = keycloak.login;
 keycloak.login = (options) => {
   if (process.env.NODE_ENV !== "development") {
-    options.idpHint = "idir";
+    options.idpHint = "idir_aad";
   }
   return kcLogin(options);
 };


### PR DESCRIPTION
### Changes being made

Update UMC idp hint to idir_aad

### Context

On dev and test environments those changes are already enforced by the IDP restriction module. 
Part of https://proactionca.ent.cgi.com/jira/browse/BCMOHAD-25348
Enforcing MFA for Keycloak and OneHealthID Admin and Management Accounts


### Quality Check

- [ ] E2E/ Unit/ Integration tests have been added.
